### PR TITLE
LIBBCM-40. Configure collapse false for year facet.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -70,7 +70,7 @@ class CatalogController < ApplicationController
     #
     # :show may be set to false if you don't want the facet to be drawn in the
     # facet bar
-    config.add_facet_field 'date_sim', label: 'Date', limit: 5
+    config.add_facet_field 'date_sim', label: 'Date', limit: 5, collapse: false
     config.add_facet_field 'genre_sim', label: 'Genres', limit: 5
     config.add_facet_field 'language_sim', label: 'Language', limit: 5
     # Hide these facets if not a Collection Manager


### PR DESCRIPTION
- A javascript function is used to determine the width of the facet count and it does not work correctly if all the facets are collapsed.

https://issues.umd.edu/browse/LIBBCM-40