### PR TITLE
LIBBCM-41. Added environment banners.

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -17,6 +17,8 @@
 @import "branding";
 @import "bootstrap/variables";
 //@import "bootstrap-responsive";
+$env-banner-height: 25px;
+@import "umd_lib_environment_banner";
 
 /**
  * Snippets to extend

--- a/app/assets/stylesheets/umd_lib_environment_banner.scss
+++ b/app/assets/stylesheets/umd_lib_environment_banner.scss
@@ -1,0 +1,20 @@
+// https://confluence.umd.edu/display/LIB/Create+Environment+Banners
+.environment-banner {
+    height: $env-banner-height;
+    padding: 2px 25px;
+
+    &#environment-local {
+        background: #008000;
+        color: #fff;
+    }
+
+    &#environment-development {
+        background: #fff100;
+        color: #000;
+    }
+    
+    &#environment-staging {
+        background: #0000ff;
+        color: #fff;
+    }
+}

--- a/app/helpers/umd_lib_environment_banner_helper.rb
+++ b/app/helpers/umd_lib_environment_banner_helper.rb
@@ -1,0 +1,40 @@
+module UMDLibEnvironmentBannerHelper
+  # https://confluence.umd.edu/display/LIB/Create+Environment+Banners
+  def umd_lib_environment_banner
+    if environment
+      content_tag :div, "#{environment} Environment",
+        class: 'environment-banner',
+        id: "environment-#{environment.downcase}"
+    end
+  end
+
+  # When the banner is visible, add the extra-padding-top class
+  # to increase body padding
+  def extra_padding_top 
+    if environment
+      return 'extra-padding-top'
+    end
+  end
+
+  # Returns 'Local', 'Development', 'Staging', or nil (indicating a production
+  # server), depending on the server environment.
+  #
+  # The "ENVIRONMENT_BANNER" environment variable can optionally be used to
+  # force a particular environment setting. Use "Production" to
+  # indicate a production system on non-production servers.
+  def environment
+    # Allow override using "ENVIRONMENT_BANNER" environment variable.
+    env_var = ENV['ENVIRONMENT_BANNER']
+    return nil if !env_var.nil? && env_var.downcase == 'production'
+    return env_var if !env_var.blank?
+    
+    return 'Local' if Rails.env.development?
+    
+    hostname = `hostname -s`
+    return 'Development' if hostname =~ /dev$/
+    return 'Staging' if hostname =~ /stage$/
+    
+    # Otherwise return nil, indicating production
+  end
+
+end

--- a/app/views/modules/_header.html.erb
+++ b/app/views/modules/_header.html.erb
@@ -13,6 +13,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
+  <%= umd_lib_environment_banner %>
   <div class="custom-header">
     <div class="row">
       <div class="row-fluid whitespace-half">

--- a/config/initializers/00-inflections.rb
+++ b/config/initializers/00-inflections.rb
@@ -1,3 +1,7 @@
+# XXX: this file is named with a leading 00- to ensure that is is loaded first
+# since apparently some of the other initializer autoload magic depends on the
+# inflections being defined.
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections
@@ -10,7 +14,7 @@
 #   inflect.uncountable %w( fish sheep )
 # end
 
-# These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  # converts "umd_lib" to "UMDLib" instead of the default "UmdLib"
+  inflect.acronym 'UMD'
+end


### PR DESCRIPTION
Had to rename the inflections.rb initializer to 00-inflections.rb, so that is is guarenteed to be loaded before any of the other initializers. Otherwise, the Rails autoloading code is unable to find the UMDLibEnvironmentBannerHelper module.

https://issues.umd.edu/browse/LIBBCM-41