### PR TITLE
LIBBCM-52. Pin roo version to 2.6.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem 'active_encode', '~> 0.1.1'
 gem 'browse-everything', '~> 0.13.0'
 gem 'mediainfo', git: "https://github.com/avalonmediasystem/mediainfo.git", branch: 'avalon_fixes'
 gem 'rest-client'
-gem 'roo'
+gem 'roo', '~> 2.6'
 gem 'rubyhorn', git: "https://github.com/avalonmediasystem/rubyhorn.git", tag: 'avalon-r6'
 
 # Data Translation & Normalization

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -672,7 +672,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (3.1.1)
-    roo (2.7.1)
+    roo (2.6.0)
       nokogiri (~> 1)
       rubyzip (~> 1.1, < 2.0.0)
     rsolr (1.1.2)
@@ -915,7 +915,7 @@ DEPENDENCIES
   resque (~> 1.26.0)
   resque-scheduler (~> 4.3.0)
   rest-client
-  roo
+  roo (~> 2.6)
   rsolr (~> 1.0)
   rspec-rails
   rspec-retry


### PR DESCRIPTION
Versions of roo > 2.6.0 use the first line of a CSV file to determine how many columns are in the file. This was causing Avalon to only get the first two columns of the batch metadata files, and thus considering all batches as having missing metadata.

https://issues.umd.edu/browse/LIBBCM-52