### PR TITLE
LIBBCM-62. Specify harmony mode for uglifier.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
Must specify "harmony: true" when using ES6 syntax.
See https://github.com/lautis/uglifier#es6--es2015--harmony-mode

https://issues.umd.edu/browse/LIBBCM-62