### PR TITLE
LIBBCM-111. Add lib to auto load path.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,8 @@ module Avalon
   class Application < Rails::Application
     require 'avalon/configuration'
 
+    config.autoload_paths << Rails.root.join('lib')
+
     config.generators do |g|
       g.test_framework :rspec, :spec => true
     end


### PR DESCRIPTION
Fix for Avalon not loading BetterActiveElasticJobAdapter

https://issues.umd.edu/browse/LIBBCM-111