### PR TITLE
LIBBCM-38 Create a password reset form for Avalon

### DIFF
--- a/app/assets/stylesheets/avalon.scss
+++ b/app/assets/stylesheets/avalon.scss
@@ -1279,6 +1279,9 @@ h5.panel-title {
   border: 2px solid #eee;
   margin: 0px auto;
   padding: 8px;
+
+  a { display: block }
+  .actions { margin: 10px 0 }
 }
 
 .twitter-typeahead {

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  helper_method :new_session_path
+  rescue_from NotImplementedError, with: :unrecoverable
+
+  protected
+
+    def after_sign_in_path_for(resource_or_scope)
+      signed_in_root_path(resource_or_scope)
+    end
+
+    # some Devise views call new_session_path('user'). This just returns the new
+    # user session path.
+    def new_session_path(_resource_name)
+      new_user_session_path
+    end
+
+    def unrecoverable
+      flash[:error] = "Sorry, but it is not possible to reset your password on your account. Please contact you system administrator." 
+      redirect_to new_user_session_path
+    end
+
+end

--- a/app/models/concerns/user_recoverable.rb
+++ b/app/models/concerns/user_recoverable.rb
@@ -1,0 +1,66 @@
+module UserRecoverable
+  extend ActiveSupport::Concern
+
+  # this can be overridden depending on what your using to store a user's
+  # identity.
+  def identity_attrs
+    { email: email }
+  end
+
+  def recoverable?
+    self.class.recoverable?(identity_attrs)
+  end
+
+  def omniauthable?
+    self.class.omniauthable?
+  end
+
+  def identifiable?
+    self.class.identifiable?
+  end
+
+  def find_identity_or_raise_error
+    identity = Identity.locate(email: email)
+    raise ActiveRecord::RecordNotFound unless identity
+    identity
+  end
+
+  # Update password saving the record and clearing token. Returns true if
+  # the passwords are valid and the record was saved, false otherwise.
+  # https://github.com/plataformatec/devise/blob/master/lib/devise/models/recoverable.rb#L37-L55
+  def reset_password(new_password, new_password_confirmation)
+    super(new_password, new_password_confirmation) unless identifiable?
+    raise NotImplementedError unless recoverable?
+
+    identity = find_identity_or_raise_error
+    if new_password.present?
+      identity.password = new_password
+      identity.password_confirmation = new_password_confirmation
+      identity.save
+    else
+      errors.add(:password, :blank)
+      false
+    end
+  end
+
+  module ClassMethods
+    def recoverable?(params)
+      include?(Devise::Models::Recoverable) && Identity.exists?(params)
+    end
+
+    def omniauthable?
+      include?(Devise::Models::Omniauthable) && !omniauth_providers.empty?
+    end
+
+    def identifiable?
+      omniauthable? && omniauth_providers.include?(:identity)
+    end
+
+    def send_reset_password_instructions(attributes = {})
+      recoverable = find_or_initialize_with_errors(reset_password_keys, attributes, :not_found)
+      raise NotImplementedError unless recoverable.recoverable?
+      recoverable.send_reset_password_instructions if recoverable.persisted?
+      recoverable
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,10 +25,13 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   # devise :database_authenticatable, :registerable,
   #        :recoverable, :rememberable, :trackable, :validatable
-  devise :omniauthable
+  devise :omniauthable, :recoverable
+
+  include UserRecoverable
 
   validates :username, presence: true, uniqueness: { case_sensitive: false }
   validates :email, presence: true, uniqueness: { case_sensitive: false }
+
 
   # Method added by Blacklight; Blacklight uses #to_s on your
   # user class to get a user-displayable login/identifier for
@@ -36,6 +39,8 @@ class User < ActiveRecord::Base
   def to_s
     user_key
   end
+
+
 
   def destroy
     Bookmark.where(user_id: self.id).destroy_all

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,0 +1,27 @@
+<div class='omniauth-form controller'>
+  <h4>Change your password</h4>
+
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+    <%= devise_error_messages! %>
+    <%= f.hidden_field :reset_password_token %>
+
+    <div class="field">
+      <%= f.label :password, "New password" %><br />
+      <% if @minimum_password_length %>
+        <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+      <% end %>
+      <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password_confirmation, "Confirm new password" %><br />
+      <%= f.password_field :password_confirmation, autocomplete: "off" %>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "Change my password" %>
+    </div>
+  <% end %>
+
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,0 +1,18 @@
+<div class='omniauth-form controller'>
+  <h4>Forgot your password?</h4>
+
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+    <%= devise_error_messages! %>
+
+    <div class="field">
+      <%= f.label :email %><br />
+      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "Send me reset password instructions" %>
+    </div>
+  <% end %>
+
+  <%= render "devise/shared/links" %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,11 @@ Rails.application.routes.draw do
     end
   end
 
-  devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }, format: false
+  devise_for :users, :controllers => {
+    :omniauth_callbacks => "users/omniauth_callbacks",
+    :passwords => "users/passwords"
+  }, format: false
+
   devise_scope :user do
     match '/users/sign_in', :to => "users/sessions#new", :as => :new_user_session, via: [:get]
     match '/users/sign_out', :to => "users/sessions#destroy", :as => :destroy_user_session, via: [:get]

--- a/db/migrate/20180907123223_add_password_reset_to_user.rb
+++ b/db/migrate/20180907123223_add_password_reset_to_user.rb
@@ -1,0 +1,9 @@
+class AddPasswordResetToUser < ActiveRecord::Migration
+  def change
+    change_table :users do |t|
+      t.datetime :reset_password_sent_at
+      t.string :reset_password_token
+    end
+    add_index :users, :reset_password_token, unique: true 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180102164651) do
-
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+ActiveRecord::Schema.define(version: 20180907123223) do
 
   create_table "annotations", force: :cascade do |t|
     t.string  "uuid"
@@ -24,8 +21,8 @@ ActiveRecord::Schema.define(version: 20180102164651) do
     t.string  "type"
   end
 
-  add_index "annotations", ["playlist_item_id"], name: "index_annotations_on_playlist_item_id", using: :btree
-  add_index "annotations", ["type"], name: "index_annotations_on_type", using: :btree
+  add_index "annotations", ["playlist_item_id"], name: "index_annotations_on_playlist_item_id"
+  add_index "annotations", ["type"], name: "index_annotations_on_type"
 
   create_table "api_tokens", force: :cascade do |t|
     t.string   "token",      null: false
@@ -35,24 +32,24 @@ ActiveRecord::Schema.define(version: 20180102164651) do
     t.datetime "updated_at"
   end
 
-  add_index "api_tokens", ["token"], name: "index_api_tokens_on_token", unique: true, using: :btree
-  add_index "api_tokens", ["username"], name: "index_api_tokens_on_username", using: :btree
+  add_index "api_tokens", ["token"], name: "index_api_tokens_on_token", unique: true
+  add_index "api_tokens", ["username"], name: "index_api_tokens_on_username"
 
   create_table "batch_entries", force: :cascade do |t|
     t.integer  "batch_registries_id"
     t.text     "payload"
-    t.boolean  "complete",            default: false, null: false
-    t.boolean  "error",               default: false, null: false
+    t.boolean  "complete",                          default: false, null: false
+    t.boolean  "error",                             default: false, null: false
     t.string   "current_status"
-    t.text     "error_message"
+    t.text     "error_message",       limit: 65535
     t.string   "media_object_pid"
     t.integer  "position"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "batch_entries", ["batch_registries_id"], name: "index_batch_entries_on_batch_registries_id", using: :btree
-  add_index "batch_entries", ["position"], name: "index_batch_entries_on_position", using: :btree
+  add_index "batch_entries", ["batch_registries_id"], name: "index_batch_entries_on_batch_registries_id"
+  add_index "batch_entries", ["position"], name: "index_batch_entries_on_position"
 
   create_table "batch_registries", force: :cascade do |t|
     t.string   "file_name"
@@ -81,8 +78,8 @@ ActiveRecord::Schema.define(version: 20180102164651) do
     t.datetime "updated_at",    null: false
   end
 
-  add_index "bookmarks", ["document_id"], name: "index_bookmarks_on_document_id", using: :btree
-  add_index "bookmarks", ["user_id"], name: "index_bookmarks_on_user_id", using: :btree
+  add_index "bookmarks", ["document_id"], name: "index_bookmarks_on_document_id"
+  add_index "bookmarks", ["user_id"], name: "index_bookmarks_on_user_id"
 
   create_table "courses", force: :cascade do |t|
     t.string   "context_id"
@@ -121,7 +118,7 @@ ActiveRecord::Schema.define(version: 20180102164651) do
     t.datetime "updated_at",   null: false
   end
 
-  add_index "migration_statuses", ["source_class", "f3_pid", "datastream"], name: "index_migration_statuses", using: :btree
+  add_index "migration_statuses", ["source_class", "f3_pid", "datastream"], name: "index_migration_statuses"
 
   create_table "minter_states", force: :cascade do |t|
     t.string   "namespace",            default: "default", null: false
@@ -133,7 +130,7 @@ ActiveRecord::Schema.define(version: 20180102164651) do
     t.datetime "updated_at",                               null: false
   end
 
-  add_index "minter_states", ["namespace"], name: "index_minter_states_on_namespace", unique: true, using: :btree
+  add_index "minter_states", ["namespace"], name: "index_minter_states_on_namespace", unique: true
 
   create_table "playlist_items", force: :cascade do |t|
     t.integer  "playlist_id", null: false
@@ -143,8 +140,8 @@ ActiveRecord::Schema.define(version: 20180102164651) do
     t.datetime "updated_at"
   end
 
-  add_index "playlist_items", ["clip_id"], name: "index_playlist_items_on_clip_id", using: :btree
-  add_index "playlist_items", ["playlist_id"], name: "index_playlist_items_on_playlist_id", using: :btree
+  add_index "playlist_items", ["clip_id"], name: "index_playlist_items_on_clip_id"
+  add_index "playlist_items", ["playlist_id"], name: "index_playlist_items_on_playlist_id"
 
   create_table "playlists", force: :cascade do |t|
     t.string   "title"
@@ -157,7 +154,7 @@ ActiveRecord::Schema.define(version: 20180102164651) do
     t.string   "tags"
   end
 
-  add_index "playlists", ["user_id"], name: "index_playlists_on_user_id", using: :btree
+  add_index "playlists", ["user_id"], name: "index_playlists_on_user_id"
 
   create_table "role_maps", force: :cascade do |t|
     t.string  "entry"
@@ -172,7 +169,7 @@ ActiveRecord::Schema.define(version: 20180102164651) do
     t.datetime "updated_at",   null: false
   end
 
-  add_index "searches", ["user_id"], name: "index_searches_on_user_id", using: :btree
+  add_index "searches", ["user_id"], name: "index_searches_on_user_id"
 
   create_table "sessions", force: :cascade do |t|
     t.string   "session_id", null: false
@@ -181,8 +178,8 @@ ActiveRecord::Schema.define(version: 20180102164651) do
     t.datetime "updated_at"
   end
 
-  add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", using: :btree
-  add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
+  add_index "sessions", ["session_id"], name: "index_sessions_on_session_id"
+  add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at"
 
   create_table "stream_tokens", force: :cascade do |t|
     t.string   "token"
@@ -191,16 +188,19 @@ ActiveRecord::Schema.define(version: 20180102164651) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "username",   null: false
-    t.string   "email",      null: false
+    t.string   "username",               null: false
+    t.string   "email",                  null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "provider"
     t.string   "uid"
     t.string   "guest"
+    t.datetime "reset_password_sent_at"
+    t.string   "reset_password_token"
   end
 
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
-  add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
+  add_index "users", ["email"], name: "index_users_on_email", unique: true
+  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  add_index "users", ["username"], name: "index_users_on_username", unique: true
 
 end

--- a/spec/integration/password_recover_spec.rb
+++ b/spec/integration/password_recover_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper.rb'
+
+describe 'PasswordTest', type: :feature do
+  
+  after(:each) { Warden.test_reset! } 
+  let(:user) { FactoryGirl.create(:user) }
+  let(:identity) { Identity.create(email: user.email, password: 'wakka-wakka') }
+  let(:user_without_identity) { FactoryGirl.create(:user) }
+
+  it 'can request a password recovery' do
+    expect(identity.email).to eq(user.email)
+    Devise.stub(:friendly_token).and_return("ToAvAl0n")
+    visit new_user_password_path
+    expect(page).to have_content("Forgot your password?")
+    fill_in 'user_email', with: user.email
+    expect { click_button 'Send me reset password instructions' }
+      .to change { ActionMailer::Base.deliveries.count }.by(1)
+
+    expect(page).to have_current_path("/users/auth/identity")
+    expect(page).to have_content("You will receive an email with instructions about how to reset your password in a few minutes")
+    mail = ActionMailer::Base.deliveries.last.body.encoded
+    expect(mail).to have_content("Hello #{user.email}!")
+
+    visit edit_user_password_path(reset_password_token: "ToAvAl0n")
+    fill_in 'New password', with: '2avalon'
+    fill_in 'Confirm new password', with: '2avalon'
+    click_button 'Change my password'
+
+    expect(page).to have_current_path('/')
+    expect(page).to have_content("Your password was changed successfully")
+    expect(page).to have_content("You are now signed in")
+    expect(page).to have_content(user.username)
+    expect(identity.reload.authenticate('2avalon')).not_to be_falsey
+  end
+
+  it 'can not request a password recovery if the account doesnt have an identity' do
+    visit new_user_password_path
+    expect(user_without_identity).not_to receive(:send_reset_password_instructions) 
+    expect(page).to have_content("Forgot your password?")
+    fill_in 'user_email', with: user_without_identity.email
+
+    expect { click_button 'Send me reset password instructions' }
+      .to change { ActionMailer::Base.deliveries.count }.by(0)
+
+    expect(page).to have_current_path("/users/auth/identity")
+    expect(page).to have_content("Sorry, but it is not possible to reset your password on your account")
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -130,7 +130,8 @@ RSpec.configure do |config|
   # config.include FactoryGirl::Syntax::Methods
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include ControllerMacros, type: :controller
-  config.include Warden::Test::Helpers,type: :feature
+  config.include Warden::Test::Helpers, type: :feature
+  config.include Rack::Test::Methods, type: :feature
   config.include FixtureMacros, type: :controller
   config.include OptionalExample
 end


### PR DESCRIPTION
This adds the ability to send a password reset email for users that are
using Omniauth Identity to log-in. Users go to the login and can request
a password reset. If their password has a matching Identity record, a
reset URL with a token is sent to their address. When the click the
link, they are given a "Create a new password" form. After the form is
submitted, their password will be updated and the user will be logged
in.

https://issues.umd.edu/browse/LIBBCM-38