### PR TITLE
LIBBCM-120 Display user exists message on duplicate registration

### DIFF
--- a/app/controllers/auth_forms_controller.rb
+++ b/app/controllers/auth_forms_controller.rb
@@ -22,24 +22,44 @@ class AuthFormsController < ApplicationController
     klass.phase = phase
     klass
   end
-  
+
   def render_form
-    render html: omniauth_form(request.class.provider, request.class.phase).html_safe, layout: true
-  end
-  
-  private
-  def omniauth_form(strategy_name, phase=:request_phase)
-    opts = Devise.omniauth_configs[strategy_name].options
-    strategy_class = Devise.omniauth_configs[strategy_name].strategy_class
-    strategy = strategy_class.new(opts)
-    html = strategy.send(phase).last.body.first.strip
-    doc = Nokogiri::HTML(html)
-    form = doc.at_xpath('//form')
-    form.xpath('label|input').to_a.in_groups_of(2).each do |label, input|
-      input['class'] = 'form-control'
-      label.replace('<div class="form-group"/>').first.add_child(label).add_next_sibling(input)
+    build_omniauth_form do |form|
+      render html: form.html_safe, layout: true
     end
-    form.xpath('button').each { |btn| btn['class'] = 'btn btn-primary' }
-    %{<div class="omniauth-form container">#{form.to_html}</div>}
   end
+
+  def render_form_with_errors
+    add_errors_to_flash
+    build_omniauth_form do |form|
+      render html: form.html_safe, layout: true
+    end
+  end
+
+  private
+
+    def add_errors_to_flash
+      model = request.env["omniauth.#{strategy.name}"]
+      flash[:error] = model.errors.to_a
+    end
+
+    def strategy
+      strategy_name = request.class.provider
+      opts = Devise.omniauth_configs[strategy_name].options
+      strategy_class = Devise.omniauth_configs[strategy_name].strategy_class
+      strategy_class.new(opts)
+    end
+
+    def build_omniauth_form
+      html = strategy.send(request.class.phase).last.body.first.strip
+      doc = Nokogiri::HTML(html)
+      form = doc.at_xpath('//form')
+      form.xpath('label|input').to_a.in_groups_of(2).each do |label, input|
+        input['class'] = 'form-control'
+        label.replace('<div class="form-group"/>').first.add_child(label).add_next_sibling(input)
+      end
+      form.at_xpath('//input[last()]').add_next_sibling view_context.hidden_field_tag(:authenticity_token, view_context.form_authenticity_token) 
+      form.xpath('button').each { |btn| btn['class'] = 'btn btn-primary' }
+      yield(%{<div class="omniauth-form container">#{form.to_html}</div>})
+    end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -257,7 +257,8 @@ Devise.setup do |config|
     if provider[:provider] == :identity
       provider[:params].merge!({
         on_login: AuthFormsController.action(:render_form, AuthFormsController.dispatcher(:identity, :request_phase)),
-        on_registration: AuthFormsController.action(:render_form, AuthFormsController.dispatcher(:identity, :registration_form))
+        on_registration: AuthFormsController.action(:render_form, AuthFormsController.dispatcher(:identity, :registration_form)),
+        on_failed_registration: AuthFormsController.action(:render_form_with_errors, AuthFormsController.dispatcher(:identity, :registration_form)),
       })
     end
 


### PR DESCRIPTION
Currently omniauth-identity will just log in a user if the user account
already exists. This adds a failure message and redirects the user back
to the form.

https://issues.umd.edu/browse/LIBBCM-120