### PR TITLE
LIBBCM-140. Add option to delete solr collection.

### DIFF
--- a/app/services/solr_collection_admin.rb
+++ b/app/services/solr_collection_admin.rb
@@ -22,4 +22,9 @@ class SolrCollectionAdmin
     response.body
   end
 
+  def delete
+    params = { action: 'DELETE', name: @collection, wt: 'json' }
+    response = @conn.get('admin/collections', params)
+    response.body
+  end
 end


### PR DESCRIPTION
To be able to restore a collection from backup requires that name does not already exist.

https://issues.umd.edu/browse/LIBBCM-140