### PR TITLE
LIBAVALON-89. Fix login error.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -146,9 +146,9 @@ class User < ActiveRecord::Base
     email = auth_hash.info.email.first
     username = email
     user = find_or_create_by_username_or_email(username, email, 'saml')
-    roles = sanitize_saml_roles(auth_hash.info.roles)
-    update_local_roles(username, roles)
+    roles = sanitize_saml_roles(auth_hash.info.roles || [])
     Rails.logger.debug "SAML Roles for user #{username}: #{roles.inspect}"
+    update_local_roles(username, roles)
     user
   end
 


### PR DESCRIPTION
When there is no Grouper group associated with an user, the login attempt was failing with NPE.

https://issues.umd.edu/browse/LIBAVALON-89