### PR TITLE
LIBAVALON-128. Move files to collection dir.

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -543,6 +543,16 @@ class MasterFile < ActiveFedora::Base
     end
   end
 
+  # Start LIBAVALON-128
+  def move_file_to_path(desination_path)
+    return false if (File.exists?(desination_path))
+    old_path = file_location;
+    FileUtils.mkdir_p(File.dirname(desination_path))
+    FileUtils.mv(old_path, desination_path)
+    self.file_location = desination_path
+  end
+  # End LIBAVALON-128
+
   protected
 
   def mediainfo

--- a/app/services/master_file_builder.rb
+++ b/app/services/master_file_builder.rb
@@ -41,6 +41,16 @@ module MasterFileBuilder
       master_file = MasterFile.new()
       master_file.setContent(spec.content)
       master_file.set_workflow(spec.workflow)
+      
+      # Start LIBAVALON-128
+      collection_path = media_object.collection.dropbox_absolute_path
+      desination_path = File.join(collection_path, 'uploads', DateTime.now.strftime("%Y%m%d"), spec.content.original_filename)
+      unless master_file.move_file_to_path(desination_path)
+        response[:flash][:error] << "Duplicate file. File already exists at path #{desination_path}!"
+        master_file.destroy
+        next
+      end
+      # End LIBAVALON-128
 
       if 'Unknown' == master_file.file_format
         response[:flash][:error] << "The file was not recognized as audio or video - %s (%s)" % [spec.original_filename, spec.content_type]


### PR DESCRIPTION
Uploaded files are stored in tmp directory by default, and they are not moved to persistent storage location when the working_file_path is not set. The 'working_file_path' option is not enabled in UMD Avalon to retain the masterfiles from batch uploads in the dropbox directory.

Move uploaded files from /tmp to the 'upload/<DATE>' directory within the collection dropbox directory.

https://issues.umd.edu/browse/LIBAVALON-128