### PR TITLE
LIBAVALON-168. Change restricted content behavior.

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -263,3 +263,41 @@ h1 small, h1 .small, h2 small, h2 .small, h3 small, h3 .small, h4 small, .facets
     padding: 0;
   }
 }
+
+/* Restricted Playback */
+.restricted-video {
+  background-color: #000;
+  vertical-align: middle;
+  width: 100%;
+  font-family: arial, helvetica, sans-serif;
+}
+
+.restricted-video-message {
+  padding: 3rem 3rem 5rem 10rem ;
+  position: relative;
+  line-height: 1.4;
+  color: white;
+  font-weight: bold;
+  font-size: 14px;
+  width: 100%;
+}
+
+.restricted-video-message h3 {
+  color: white;
+}
+
+.restricted-video-message::before {
+  display: block;
+  position: absolute;
+  left: 3rem;
+  top: 5rem;
+  content: "!";
+  border-radius: 50%;
+  border: 0.4rem solid white;
+  width: 5rem;
+  height: 5rem;
+  line-height: 4rem;
+  text-align: center;
+  color: white;
+  font-size: x-large;
+}

--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -304,7 +304,7 @@ class MasterFilesController < ApplicationController
       opts = { :type => params[:type], :size => params[:size], :offset => params[:offset].to_f*1000, :preview => true }
       master_file.extract_still(opts)
     else
-      authorize! :read, master_file, message: "You do not have sufficient privileges to view this file"
+      authorize! :minimal_read, master_file, message: "You do not have sufficient privileges to view this file"
       whitelist = ["thumbnail", "poster"]
       if whitelist.include? params[:type]
         ds = master_file.send(params[:type].to_sym)

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -324,6 +324,7 @@ class MediaObjectsController < ApplicationController
   end
 
   def show
+    @playback_restricted = cannot? :full_read, @media_object
     respond_to do |format|
       format.html do
         if (not @masterFiles.empty? and @currentStream.blank?) then

--- a/app/controllers/supplemental_files_controller.rb
+++ b/app/controllers/supplemental_files_controller.rb
@@ -145,6 +145,8 @@ class SupplementalFilesController < ApplicationController
     end
 
     def authorize_object
-      authorize! action_name.to_sym, @object, message: "You do not have sufficient privileges to #{action_name} this supplemental file"
+      action = action_name.to_sym
+      action = :full_read if action == :show && @object.is_a?(MediaObject)
+      authorize! action, @object, message: "You do not have sufficient privileges to #{action_name} this supplemental file"
     end
 end

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -230,6 +230,8 @@ class MediaObject < ActiveFedora::Base
       solr_doc['read_access_ip_group_ssim'] = collect_ips_for_index(ip_read_groups + leases('ip').map(&:inherited_read_groups).flatten)
       solr_doc[Hydra.config.permissions.read.group] ||= []
       solr_doc[Hydra.config.permissions.read.group] += solr_doc['read_access_ip_group_ssim']
+      solr_doc[Hydra.config.permissions.discover.group] ||= [] # Customization for LIBAVALON-168
+      solr_doc[Hydra.config.permissions.discover.group] += ['public'] # Customization for LIBAVALON-168
       solr_doc["title_ssort"] = self.title
       solr_doc["creator_ssort"] = Array(self.creator).join(', ')
       solr_doc["date_digitized_sim"] = master_files.collect {|mf| mf.date_digitized }.compact.map {|t| Time.parse(t).strftime "%F" }

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -25,14 +25,25 @@ Unless required by applicable law or agreed to in writing, software distributed
     <% if @playback_restricted %>
     <div class="restricted-video">
       <div class="restricted-video-message">
-        <h3>Playback Restricted</h3>
-        The content playback is restricted!
+      <h3>Playback Restricted</h3>
+      <% if @media_object.collection.name.starts_with?('The Jim Henson Works') %>
+      Digital videos from The Jim Henson Works are available for viewing only from public computers at these locations:
+      <ul>
+        <li><a href="https://www.lib.umd.edu/mspal">Michelle Smith Performing Arts Library</a></li>
+        <li><a href="https://www.lib.umd.edu/hornbake">Hornbake Library</a></li>
+        <li><a href="https://www.lib.umd.edu/mckeldin">McKeldin Library</a></li>
+      </ul>
+      <% else %>
+      This content is available for streaming only at the University of Maryland's College Park campus or through a <a href="https://digital.lib.umd.edu/help_video#vpn">VPN connection</a>. This content may be accessed from public computers at any of the UMD Libraries on the College Park campus.
+      <br/>
+      <br/>
+      <% end %>
+      <span>Questions? <a href="https://www.lib.umd.edu/digital/contact/digital-feedback">Contact Us</a></span>
       </div>
     </div>
     <% else %>
     <%= render partial: "modules/player/section", locals: {section: @currentStream, section_info: @currentStreamInfo, f_start: @f_start, f_end: @f_end} %>
 
-    <%= render file: '_track_scrubber.html.erb' if is_mejs_2? %>
     <%= render file: '_add_to_playlist.html.erb' if current_user.present? && is_mejs_2? %>
     <%# Partial view for MEJS4 Add To Playlist plugin %>
     <%= render partial: 'mejs4_add_to_playlist' if current_user.present? && is_mejs_4? %>

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -22,6 +22,14 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% f_start, f_end = parse_media_fragment params['t'] %>
 <div class="row">
   <div class="col-sm-8" id="left_column">
+    <% if @playback_restricted %>
+    <div class="restricted-video">
+      <div class="restricted-video-message">
+        <h3>Playback Restricted</h3>
+        The content playback is restricted!
+      </div>
+    </div>
+    <% else %>
     <%= render partial: "modules/player/section", locals: {section: @currentStream, section_info: @currentStreamInfo, f_start: @f_start, f_end: @f_end} %>
 
     <%= render file: '_track_scrubber.html.erb' if is_mejs_2? %>
@@ -37,6 +45,7 @@ Unless required by applicable law or agreed to in writing, software distributed
         locals: { mediaobject: @media_object,
                  sections: @masterFiles,
                  activeStream: @currentStream } %>
+    <% end %>
   </div>
   <div class="col-sm-4" id="right-column">
     <%# LIBAVALON-93 - Start Aeon button. %>


### PR DESCRIPTION
- Add "public" discover group to all MediaObjects in Solr index.
- Show metadata for restricted items.
- Media playback and supplemental file access still remains restricted.

https://issues.umd.edu/browse/LIBAVALON-168