### PR TITLE
LIBAVALON-173. Improve local development environment setup

### DIFF
--- a/UMD-README.md
+++ b/UMD-README.md
@@ -48,7 +48,7 @@ Edit the "/etc/hosts" file and add
 
     ```bash
     docker-compose pull
-    docker-compose up
+    docker-compose up avalon worker
     ```
 
 Avalon should be available at: [http://av-local:3000](http://av-local:3000)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,7 @@ services:
       - ENCODE_WORK_DIR=/streamfiles
       - CONTROLLED_VOCABULARY=config/controlled_vocabulary.yml
       - DATABASE_URL=postgres://postgres:password@db/avalon
+      - DIGITAL_COLLECTIONS_URL=https://digital.lib.umd.edu/
       - FEDORA_NAMESPACE=avalon
       - FEDORA_URL=http://fedoraAdmin:fedoraAdmin@fedora:8080/fedora/rest
       - RAILS_ENV=development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
       - streaming:/streamfiles
       - npms:/home/app/avalon/node_modules
     ports:
-      - '3001:3000'
+      - '3000:3000'
     networks:
       internal:
       external:


### PR DESCRIPTION
Modified the configuration, restoring the Avalon Rails application to
run on port 3000, instead of port 3001. It is believed that the configuration change to run on port 3001 was
inadvertent (caused by a port conflict when working with the
"umd-handle" Rails application).

The Avalon "README.md" indicates that the system should be started using
`docker-compose up avalon worker` which only runs the containers
necessary for Avalon (skipping the test containers). Modified the
"UMD-README.md" to use this command, to avoid the spurious
warnings/errors in the log

Added "DIGITAL_COLLECTIONS_URL" to the Avalon environment, as it is
used by the HTML templates. Without this environment variable, accessing the "Manage | Manage Users"
link in Avalon displays an error.


https://issues.umd.edu/browse/LIBAVALON-173