### PR TITLE
LIBAVALON-156. Fix "span" tag in pagination section of modal dialogs

### DIFF
--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -1,0 +1,19 @@
+<div class="prev_next_links btn-group pull-left">
+  <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link', data: { ajax_modal: "preserve" } do %>
+    <%= content_tag :span, raw(t('views.pagination.previous')), class: 'disabled btn btn-disabled' %>
+  <% end %>
+
+  <%= link_to_next_page @pagination, raw(t('views.pagination.next')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link',  data: { ajax_modal: "preserve" } do %>
+    <%= content_tag :span, raw(t('views.pagination.next')), class: 'disabled btn btn-disabled' %>
+  <% end %>
+</div>
+
+<div class="sort_options btn-group pull-right">
+  <% if @pagination.sort == 'index' -%>
+    <span class="active az btn btn-default"><%= t('blacklight.search.facets.sort.index') %></span>
+    <%= link_to(t('blacklight.search.facets.sort.count'), @pagination.params_for_resort_url('count', search_state.to_h), class: "sort_change numeric btn btn-default", data: { ajax_modal: "preserve" }) %>
+  <% elsif @pagination.sort == 'count' -%>
+    <%=  link_to(t('blacklight.search.facets.sort.index'), @pagination.params_for_resort_url('index', search_state.to_h), class: "sort_change az btn btn-default",  data: { ajax_modal: "preserve" }) %>
+    <span class="active numeric btn btn-default"><%= t('blacklight.search.facets.sort.count') %></span>
+  <% end -%>
+</div>


### PR DESCRIPTION
Fixes extraneous "</span>" tags showing in the pagination section
of modal dialogs. This is a core Avalon issue, coming from the
"blacklight" gem.

This file was taken from an upstream Avalon fix that will be included in
Avalon v7.3 (see https://github.com/avalonmediasystem/avalon/pull/4335).

https://issues.umd.edu/browse/LIBAVALON-156