### PR TITLE
LIBAVALON-106. Set default thumbnail for videos

### DIFF
--- a/app/models/master_file.rb
+++ b/app/models/master_file.rb
@@ -318,6 +318,18 @@ class MasterFile < ActiveFedora::Base
     save
   end
 
+  def set_default_thumbnail
+    if is_video?
+      thumbnail.content=StringIO.new(File.read('app/assets/images/video_icon.png', encoding: 'BINARY'))
+      thumbnail.mime_type='image/png'
+      thumbnail.original_name='video_icon.png'
+      thumbnail.save
+      save
+      reload
+      thumbnail.reload
+    end
+  end
+
   alias_method :'_poster_offset', :'poster_offset'
   def poster_offset
     _poster_offset.to_i
@@ -387,6 +399,7 @@ class MasterFile < ActiveFedora::Base
         unless options[:preview]
           file.mime_type = 'image/jpeg'
           file.content = StringIO.new(result)
+          file.original_name = 'thumbnail.jpg' if type == 'thumbnail'
         end
       end
     end

--- a/app/services/master_file_builder.rb
+++ b/app/services/master_file_builder.rb
@@ -65,6 +65,10 @@ module MasterFileBuilder
       if master_file.save
         media_object.save
         master_file.process
+
+        # Replace thumbnail (for videos) with default thumbnail
+        master_file.set_default_thumbnail
+
         response[:master_files] << master_file
       else
         response[:flash][:error] << "There was a problem storing the file"

--- a/lib/avalon/batch/entry.rb
+++ b/lib/avalon/batch/entry.rb
@@ -220,6 +220,9 @@ module Avalon
             master_file.media_object = media_object
             media_object.save
             master_file.process(files)
+
+            # Replace thumbnail (for videos) with default thumbnail
+            master_file.set_default_thumbnail
           else
             Rails.logger.error "Problem saving MasterFile(#{master_file.id}): #{master_file.errors.full_messages.to_sentence}"
           end

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -310,8 +310,8 @@ describe MasterFilesController do
 
       it "returns thumbnail" do
         get :get_frame, params: { id: mf.id, type: 'thumbnail', size: 'bar' }
-        expect(response.body).to eq('fake image content')
-        expect(response.headers['Content-Type']).to eq('image/jpeg')
+        # get_frame returns default "video_icon.png"
+        expect(response.headers['Content-Type']).to eq('image/png')
       end
 
       it "returns offset thumbnail" do
@@ -645,10 +645,10 @@ describe MasterFilesController do
 
   describe "#update" do
     let(:master_file) { FactoryBot.create(:master_file, :with_media_object) }
-    subject { put('update', params: { id: master_file.id, 
-                                      master_file: { title: "New label", 
-                                                    poster_offset: "00:00:03", 
-                                                    date_digitized: "2020-08-27", 
+    subject { put('update', params: { id: master_file.id,
+                                      master_file: { title: "New label",
+                                                    poster_offset: "00:00:03",
+                                                    date_digitized: "2020-08-27",
                                                     permalink: "https://perma.link" }})}
 
     before do

--- a/spec/factories/master_files.rb
+++ b/spec/factories/master_files.rb
@@ -49,8 +49,7 @@ FactoryBot.define do
     end
     trait :with_thumbnail do
       after(:create) do |mf|
-        mf.thumbnail.mime_type = 'image/jpeg'
-        mf.thumbnail.content = 'fake image content'
+        mf.set_default_thumbnail
         mf.save
       end
     end

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -535,9 +535,18 @@ describe MasterFile do
   end
 
   describe 'thumbnail' do
-    let(:master_file) { FactoryBot.create(:master_file) }
-    it 'sets original_name to default value' do
-      expect(master_file.thumbnail.original_name).to eq 'thumbnail.jpg'
+    let(:master_file) { FactoryBot.create(:master_file, :with_thumbnail) }
+    it 'uses a default icon for videos' do
+      expect(master_file.thumbnail.original_name).to eq 'video_icon.png'
+    end
+    it 'uses a default icon for audio' do
+      master_file.file_format = 'Sound'
+      master_file.set_workflow
+      master_file.thumbnail.original_name = 'audio_icon.png'
+
+      # Setting default thumbnail should not change the current thumbnail
+      master_file.set_default_thumbnail
+      expect(master_file.thumbnail.original_name).to eq 'audio_icon.png'
     end
   end
 


### PR DESCRIPTION
**Note: This pull request needs to be demonstrated/approved by stakeholders before being merged.**

Modified MasteFile generation to replace the "thumbnail" image derived
from the video file, with a stock default thumbnail image.

This prevents a multitude of videos with black/empty thumbnail images
from being displayed on the "Browse" page, and provides a visual
indication to curators that a thumbnail needs to be chosen.

Added a "set_default_thumbnail" method the "MasterFile" class, and
modified the MasterFileBuilder (called when a item is added manually)
and the "Avalon::Batch::Entry" class (called when an item is added
via a batch process) to call the method.

Updated rspec tests to reflect changes.

https://issues.umd.edu/browse/LIBAVALON-106