### PR TITLE
LIBAVALON-196. Protect the access copy by removing from the dropbox after ingest

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -52,8 +52,8 @@ redis:
 groups:
   system_groups: [administrator, group_manager, manager]
 master_file_management:
-  strategy: 'none' #'delete', or 'move' (for move uncomment and configure next line)
-  #path: '/path/to/move/to'
+  strategy: 'move' #'delete', or 'move' (for move uncomment and configure next line)
+  path: '/masterfiles/archive'
 bib_retriever:
   default:
     protocol: sru

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -463,6 +463,18 @@ describe MasterFile do
     end
   end
 
+  describe '#post_processing_move_relative_filepath' do
+    let(:id) { '0z708w40c' }
+    let(:path) { '/path/to/video.mp4' }
+    it 'returns a filepath based on the id' do
+      expect(MasterFile.post_processing_move_relative_filepath(path, id: id)).to eq '0z/70/8w/40/0z708w40c-video.mp4'
+    end
+    it 'does not prepend the id if already present' do
+      path = '/path/to/0z708w40c-video.mp4'
+      expect(MasterFile.post_processing_move_relative_filepath(path, id: id)).to eq '0z/70/8w/40/0z708w40c-video.mp4'
+    end
+  end
+
   describe '#post_processing_move_filename' do
     let(:id) { 'avalon:12345' }
     let(:id_prefix) { 'avalon_12345' }


### PR DESCRIPTION
Modified the "config/settings.yml" file to move master file binaries (access copies) from the dropbox directory, to an "archive" directory as part of the upload process.

The "archive" directory is configured to be the "/masterfile/archive" directory, which makes it a sibling to the "dropbox" directory.

Added a "post_processing_move_relative_filepath" method to "app/models/master_file.rb" which generates a relative filepath built from the media object id, using the "Noid::Rails.treeify" method. This is the same method used to "mint" Fedora identifiers (see "ActiveFedora::Base.translate_id_to_uri" in "config/initializers/active_fedora_general.rb"

Modified the "manage_master_file" method to use the "post_processing_move_relative_filepath" method when naming files.

Added RSpec tests for the "post_processing_move_relative_filepath" method.

https://issues.umd.edu/browse/LIBAVALON-196