### PR TITLE
LIBAVALON-197. Add option to download the access copy

### DIFF
--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -323,8 +323,22 @@ class MediaObjectsController < ApplicationController
     end
   end
 
+  # Begin customization for LIBAVALON-196
+  def master_file_download_allowed?
+    return false if @masterFiles.empty?
+
+    download_allowed = true
+    @masterFiles.each do |master_file|
+      master_file = master_file.real_object if master_file.is_a? SpeedyAF::Proxy::MasterFile
+      download_allowed = download_allowed && can?(:master_file_download, master_file)
+    end
+    download_allowed
+  end
+  # End customization for LIBAVALON-196
+
   def show
     @playback_restricted = cannot? :full_read, @media_object
+    @master_file_download_allowed = master_file_download_allowed?
     respond_to do |format|
       format.html do
         if (not @masterFiles.empty? and @currentStream.blank?) then

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -83,6 +83,13 @@ class Ability
       end
       # End customization for LIBAVALON-168
 
+      # Begin customization for LIBAVALON-196
+      can :master_file_download, MasterFile do |master_file|
+        collection = master_file&.media_object&.collection
+        is_member_of?(collection) unless collection.nil?
+      end
+      # End customization for LIBAVALON-196
+
       cannot :read, Admin::Collection unless (full_login? || is_api_request?)
 
       if full_login? || is_api_request?

--- a/app/views/media_objects/_metadata_display.html.erb
+++ b/app/views/media_objects/_metadata_display.html.erb
@@ -65,6 +65,24 @@ Unless required by applicable law or agreed to in writing, software distributed
     <% end %>
   </div>
 
+  <%if @master_file_download_allowed %>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">
+          Downloads
+        </h3>
+      </div>
+      <div class="panel-body">
+        <ul>
+        <% @masterFiles.each do |master_file| %>
+          <li>
+          <%= link_to(File.basename(master_file.file_location), download_master_file_path(id: master_file.id)) %>
+          </li>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
   <div class="panel panel-default">
     <div class="panel-heading">
       <h3 class="panel-title">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,11 @@ en:
     empty_share_link: ""
     empty_share_link_notice: "After processing has started the embedded link will be available."
     empty_share_section_permalink_notice: "After processing has started the section link will be available."
+  master_file:
+    error_id_not_found: "Download failed: Cannot find master file with id: %{id}"
+    error_no_file: "Download failed: Original file not stored."
+    error_file_not_found: "Download failed: File not found at: %{location}"
+    download_not_permitted: "Download not permitted."
   metadata_tip:
     abstract: |
       Summary provides a space for describing the contents of the item. Examples
@@ -246,7 +251,7 @@ en:
       timeline:
         title: "Title"
         description: "Description"
-      user:  
+      user:
         login: "Username or email"
 
   iiif:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,6 +140,7 @@ Rails.application.routes.draw do
       post 'thumbnail', :to => 'master_files#set_frame', :defaults => { :type => 'thumbnail', :format => 'html' }
       post 'poster',    :to => 'master_files#set_frame', :defaults => { :type => 'poster', :format => 'html' }
       post 'still',     :to => 'master_files#set_frame', :defaults => { :format => 'html' }
+      get :download
       get :embed
       post 'attach_structure'
       post 'attach_captions'

--- a/spec/controllers/master_files_controller_spec.rb
+++ b/spec/controllers/master_files_controller_spec.rb
@@ -234,6 +234,76 @@ describe MasterFilesController do
     end
   end
 
+  describe "#download" do
+    it "fails if invalid id is provided" do
+      get(:download, params: { id: 'invalid_id'})
+      expect(flash[:alert]).to match(I18n.t('master_file.error_id_not_found', id:  'invalid_id'))
+
+      # Redirects back to application home page when no referrer
+      expect(response).to redirect_to(root_url)
+
+      # Redirects back to referrer if "HTTP_REFERER" is set
+      request.env["HTTP_REFERER"] = "/referring_url"
+      get(:download, params: { id: 'invalid_id'})
+      expect(response).to redirect_to(root_url + "referring_url")
+    end
+
+    it "fails if download is not permitted" do
+      master_file = FactoryBot.create(:master_file, :with_media_object)
+      master_file_id = master_file.id
+
+      login_as :user
+      get(:download, params: { id: master_file_id})
+
+      expect(flash[:notice]).to match(I18n.t('master_file.download_not_permitted'))
+      expect(response).to redirect_to(root_url)
+    end
+
+    it "fails if master_file has no file_location" do
+      master_file = FactoryBot.create(:master_file, :with_media_object)
+      master_file.file_location = nil
+      master_file.save!
+      master_file_id = master_file.id
+
+      login_as :administrator
+      get(:download, params: { id: master_file_id})
+
+      expect(flash[:alert]).to match(I18n.t('master_file.error_no_file'))
+      expect(response).to redirect_to(root_url)
+    end
+
+    it "fails if file not found at master_file.file_location" do
+      master_file = FactoryBot.create(:master_file, :with_media_object)
+      master_file_id = master_file.id
+      master_file.file_location = '/file/location/does/not/exist.mp4'
+      master_file.save!
+
+      login_as :administrator
+      get(:download, params: { id: master_file_id})
+
+      expect(flash[:alert]).to match(I18n.t('master_file.error_file_not_found', location: master_file.file_location))
+      expect(response).to redirect_to(root_url)
+    end
+
+    it "provides the file for download, if permitted" do
+      fixture_file_dir = Rails.root.join('spec', 'fixtures')
+      fixture_filename = 'videoshort.mp4'
+      with_temporary_copy_of_file(fixture_file_dir, fixture_filename) do |tmp_file_pathname|
+        master_file = FactoryBot.create(:master_file, :with_media_object)
+        master_file.file_location = tmp_file_pathname.to_s
+        master_file.save!
+        master_file_id = master_file.id
+        editor_username = master_file.media_object.collection.editors.first
+        login_user editor_username
+
+        expect(@controller).to receive(:send_file).with(tmp_file_pathname.to_s).and_call_original
+
+        get(:download, params: { id: master_file_id})
+      end
+    end
+
+
+  end
   describe "#show" do
     let(:master_file) { FactoryBot.create(:master_file, :with_media_object) }
 

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -834,6 +834,27 @@ describe MediaObjectsController, type: :controller do
       end
     end
 
+    context "master_file_download" do
+      it "should not display when there is no master file" do
+        login_as(:administrator)
+        get :show, params: { id: media_object.id }
+        expect(controller.instance_variable_get('@master_file_download_allowed')).to be false
+      end
+
+      let(:media_object_with_master_file) { FactoryBot.create(:published_media_object, :with_master_file) }
+
+      it "should display when permitted" do
+        login_as(:administrator)
+        get :show, params: { id: media_object_with_master_file.id }
+        expect(controller.instance_variable_get('@master_file_download_allowed')).to be true
+      end
+      it "should not display when not permitted" do
+        login_as :public
+        get :show, params: { id: media_object_with_master_file.id }
+        expect(controller.instance_variable_get('@master_file_download_allowed')).to be false
+      end
+    end
+
     context "correctly handle unfound streams/sections" do
       subject(:mo){FactoryBot.create(:media_object, :with_master_file)}
       before do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -13,11 +13,58 @@
 # ---  END LICENSE_HEADER BLOCK  ---
 
 require 'rails_helper'
+require "cancan/matchers"
 
 describe Ability, type: :model do
   describe 'non-logged in users' do
     it 'only belongs to the public group' do
       expect(Ability.new(nil).user_groups).to eq ["public"]
+    end
+  end
+end
+
+describe 'masterfile_download Ability' do
+  let(:published_media_object) { FactoryBot.create(:published_media_object) }
+  let(:master_file) { FactoryBot.create(:master_file, media_object: published_media_object) }
+
+  it 'is not available if master_file does not have associated media_object' do
+    master_file = FactoryBot.create(:master_file)
+    # Need to use "user" instead of "admin", because "admin" skips permissions
+    # check.
+    ability = Ability.new(FactoryBot.create(:user))
+    expect(ability).to_not be_able_to(:master_file_download, master_file)
+  end
+
+  it 'is not available to non-logged in users' do
+    ability = Ability.new(nil)
+    expect(ability).to_not be_able_to(:master_file_download, master_file)
+  end
+
+  it 'is available to admin users' do
+    ability = Ability.new(FactoryBot.create(:admin))
+    expect(ability).to be_able_to(:master_file_download, master_file)
+  end
+
+  it 'is available to managers, editors, and depositors of the collection' do
+    collection_users = master_file.media_object.collection.managers +
+                       master_file.media_object.collection.editors +
+                       master_file.media_object.collection.depositors
+    collection_users.each do |user_name|
+      ability = Ability.new(User.find_by(username: user_name))
+      expect(ability).to be_able_to(:master_file_download, master_file)
+    end
+  end
+
+  it 'is not available to managers, editors, and depositors of other collections' do
+    other_collection = FactoryBot.build(:collection)
+
+    other_collection_users = other_collection.managers +
+                             other_collection.editors +
+                             other_collection.depositors
+
+    other_collection_users.each do |user_name|
+      ability = Ability.new(User.find_by(username: user_name))
+      expect(ability).to_not be_able_to(:master_file_download, master_file)
     end
   end
 end


### PR DESCRIPTION
Added "master_file_download" permission to "ability.rb", which allows
a master file (i.e., "access copy") to be downloaded if the user is
a member of the collection the media_object associated with the master
file is part of. Due to the way permissions are setup, "admin" users
bypass this permission check entirely.

Updated "app/controllers/media_objects_controller.rb" to determine if
master file downloads are allowed. In the case of multiple master files,
all master files must be downloadable (this is not expected to be an
issue in practice, as all the files should be part of the same
collection).

Added a "Downloads" section to
"app/views/media_objects/_metadata_display.html.erb" that presents a
download link for each master file, if permitted.

Added "download" endpoint to the
"/app/controllers/master_files_controller.rb" that enables
a master file (i.e., "access copy") to be downloaded, if permitted.

Added the "download" endpoint to "config/routes.db"

Added RSpec tests for new functionality.

https://issues.umd.edu/browse/LIBAVALON-197