### PR TITLE
LIBAVALON-206. Added token based access to master file downloads

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -151,6 +151,10 @@ class ApplicationController < ActionController::Base
   def current_ability
     session_opts ||= user_session
     session_opts ||= {}
+
+    access_token = request.params[:access_token]
+    session_opts = session_opts.merge(access_token: access_token) if access_token
+
     @current_ability ||= Ability.new(current_user, session_opts.merge(remote_ip: request.ip))
   end
 

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -339,6 +339,8 @@ class MediaObjectsController < ApplicationController
   def show
     @playback_restricted = cannot? :full_read, @media_object
     @master_file_download_allowed = master_file_download_allowed?
+    @access_token = params[:access_token]
+
     respond_to do |format|
       format.html do
         if (not @masterFiles.empty? and @currentStream.blank?) then

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -325,7 +325,7 @@ class MediaObjectsController < ApplicationController
 
   # Begin customization for LIBAVALON-196
   def master_file_download_allowed?
-    return false if @masterFiles.empty?
+    return false if @masterFiles.nil? || @masterFiles.empty?
 
     download_allowed = true
     @masterFiles.each do |master_file|

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -24,6 +24,12 @@ class Ability
     can :read, :encode_dashboard if is_administrator?
   end
 
+  def self.access_token_download_group_name(media_object_id)
+    # Returns the group name to use if downloads are allowed for a media object
+    # via an access token
+    "allow_download_#{media_object_id}"
+  end
+
   def user_groups
     return @user_groups if @user_groups
 
@@ -32,7 +38,24 @@ class Ability
     @user_groups |= ['registered'] unless current_user.new_record?
     @user_groups |= @options[:virtual_groups] if @options.present? and @options.has_key? :virtual_groups
     @user_groups |= [@options[:remote_ip]] if @options.present? and @options.has_key? :remote_ip
+
+    if @options.has_key? :access_token
+      token = @options[:access_token]
+      @user_groups |= access_token_user_groups(token)
+    end
+
     @user_groups
+  end
+
+  def access_token_user_groups(token)
+    # Returns a list of the user groups based on the token, or an empty list.
+    return [] if token.nil?
+
+    access_token = AccessToken.find_by(token: token)
+    return [] unless !access_token.nil? && access_token.active? && access_token.allow_download?
+
+    media_object_id = access_token.media_object_id
+    [Ability.access_token_download_group_name(media_object_id)]
   end
 
   def create_permissions(user=nil, session=nil)
@@ -85,9 +108,9 @@ class Ability
 
       # Begin customization for LIBAVALON-196
       can :master_file_download, MasterFile do |master_file|
-        collection = master_file&.media_object&.collection
-        is_member_of?(collection) unless collection.nil?
+        is_master_file_download_allowed?(master_file)
       end
+
       # End customization for LIBAVALON-196
 
       cannot :read, Admin::Collection unless (full_login? || is_api_request?)
@@ -242,6 +265,21 @@ class Ability
   def is_member_of?(collection)
      is_administrator? ||
        @user.in?(collection.managers, collection.editors, collection.depositors)
+  end
+
+  def is_master_file_download_allowed?(master_file)
+    # Returns true if download of the master file is allowed, false otherwise
+    media_object = master_file&.media_object
+    return false unless media_object
+
+    media_object_id = media_object.id
+
+    collection = media_object.collection
+    return false unless collection
+
+    allowed = is_member_of?(collection)
+    allowed = allowed || @user_groups.include?(Ability.access_token_download_group_name(media_object_id))
+    allowed
   end
 
   def is_editor_of?(collection)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -39,7 +39,7 @@ class Ability
     @user_groups |= @options[:virtual_groups] if @options.present? and @options.has_key? :virtual_groups
     @user_groups |= [@options[:remote_ip]] if @options.present? and @options.has_key? :remote_ip
 
-    if @options.has_key? :access_token
+    if @options.present? && @options.has_key?(:access_token)
       token = @options[:access_token]
       @user_groups |= access_token_user_groups(token)
     end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -22,6 +22,12 @@ class AccessToken < ApplicationRecord
     self.revoked ||= false
   end
 
+  # Returns true if this token has not expired and not revoked, false
+  # otherwise.
+  def active?
+    !should_expire? && !revoked?
+  end
+
   # Checks whether the expiration time for this token is in the past.
   def should_expire?
     self.expiration.past?

--- a/app/views/media_objects/_metadata_display.html.erb
+++ b/app/views/media_objects/_metadata_display.html.erb
@@ -76,7 +76,7 @@ Unless required by applicable law or agreed to in writing, software distributed
         <ul>
         <% @masterFiles.each do |master_file| %>
           <li>
-          <%= link_to(File.basename(master_file.file_location), download_master_file_path(id: master_file.id)) %>
+          <%= link_to(File.basename(master_file.file_location), download_master_file_path(id: master_file.id, access_token: @access_token)) %>
           </li>
         <% end %>
       </div>

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -128,4 +128,17 @@ describe ApplicationController do
       expect(controller.params[:key][:subkey]).to eq "value"
     end
   end
+
+  describe '#current_ability' do
+    it 'adds access_token to session options when "access_token" param is present' do
+      access_token = FactoryBot.create(:access_token)
+      request.params['access_token'] = access_token.token
+      ability = controller.current_ability
+      expect(ability.options[:access_token]).to be(access_token.token)
+    end
+    it 'does not add access_token to session options when "access_token" param is not present' do
+      ability = controller.current_ability
+      expect(ability.options.has_key?(:access_token)).to be(false)
+    end
+  end
 end

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -848,10 +848,17 @@ describe MediaObjectsController, type: :controller do
         get :show, params: { id: media_object_with_master_file.id }
         expect(controller.instance_variable_get('@master_file_download_allowed')).to be true
       end
+
       it "should not display when not permitted" do
         login_as :public
         get :show, params: { id: media_object_with_master_file.id }
         expect(controller.instance_variable_get('@master_file_download_allowed')).to be false
+      end
+
+      it "should include @access_token variable for template when access token is provided" do
+        login_as :public
+        get :show, params: { id: media_object_with_master_file.id, access_token: 'test_access_token' }
+        expect(controller.instance_variable_get('@access_token')).to eq 'test_access_token'
       end
     end
 

--- a/spec/factories/access_token.rb
+++ b/spec/factories/access_token.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :access_token, class:AccessToken do
+  factory :access_token do
     association :user
     media_object_id { FactoryBot.create(:media_object).id }
     expiration { 7.days.from_now }

--- a/spec/factories/access_token.rb
+++ b/spec/factories/access_token.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :access_token, class:AccessToken do
+    association :user
+    media_object_id { FactoryBot.create(:media_object).id }
+    expiration { 7.days.from_now }
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -130,7 +130,7 @@ describe 'masterfile_download Ability' do
     end
   end
 
-  it 'is avaiable if an active access token allowing downloads is provided' do
+  it 'is available if an active access token allowing downloads is provided' do
     access_token = FactoryBot.create(:access_token)
     access_token.media_object_id = master_file.media_object.id
     access_token.allow_download = true

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -23,6 +23,68 @@ describe Ability, type: :model do
   end
 end
 
+describe '#user_groups' do
+  context 'when options has an "access_token" entry' do
+    let (:ability) { Ability.new(nil, { access_token: access_token.token }) }
+    let (:access_token) { FactoryBot.create(:access_token) }
+
+    it 'does not add "allow_download" group if the access token has expired' do
+      access_token.expiration = 1.day.ago
+      access_token.allow_download = true
+      access_token.save!
+      expect(access_token.should_expire?).to be(true)
+
+      user_groups = ability.user_groups
+      download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
+
+      expect(user_groups.include?(download_group_name)).to be(false)
+    end
+
+    it 'does not add "allow_download" group if the access token has been revoked' do
+      access_token.revoked = true
+      access_token.allow_download = true
+      access_token.save!
+      expect(access_token.revoked?).to be(true)
+
+      user_groups = ability.user_groups
+      download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
+
+      expect(user_groups.include?(download_group_name)).to be(false)
+    end
+
+    it 'does not add "allow_download" group if the access token is active but downloads are not allowed' do
+      expect(access_token.active?).to be(true)
+      expect(access_token.allow_download?).to be(false)
+
+      user_groups = ability.user_groups
+      download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
+
+      expect(user_groups.include?(download_group_name)).to be(false)
+    end
+
+    it 'does not add "allow_download" group if the access token does not exist' do
+      ability = Ability.new(nil, { access_token: 'does_not_exist' })
+
+      user_groups = ability.user_groups
+      download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
+
+      expect(user_groups.include?(download_group_name)).to be(false)
+    end
+
+    it 'adds an "allow_download" group if access token is active and allows downloads' do
+      access_token.allow_download = true
+      access_token.save!
+      expect(access_token.active?).to be(true)
+      expect(access_token.allow_download?).to be(true)
+
+      user_groups = ability.user_groups
+      download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
+
+      expect(user_groups.include?(download_group_name)).to be(true)
+    end
+  end
+end
+
 describe 'masterfile_download Ability' do
   let(:published_media_object) { FactoryBot.create(:published_media_object) }
   let(:master_file) { FactoryBot.create(:master_file, media_object: published_media_object) }
@@ -56,7 +118,7 @@ describe 'masterfile_download Ability' do
   end
 
   it 'is not available to managers, editors, and depositors of other collections' do
-    other_collection = FactoryBot.build(:collection)
+    other_collection = FactoryBot.create(:collection)
 
     other_collection_users = other_collection.managers +
                              other_collection.editors +
@@ -66,5 +128,16 @@ describe 'masterfile_download Ability' do
       ability = Ability.new(User.find_by(username: user_name))
       expect(ability).to_not be_able_to(:master_file_download, master_file)
     end
+  end
+
+  it 'is avaiable if an active access token allowing downloads is provided' do
+    access_token = FactoryBot.create(:access_token)
+    access_token.media_object_id = master_file.media_object.id
+    access_token.allow_download = true
+    access_token.save!
+
+    token = access_token.token
+    ability = Ability.new(nil, { access_token: token })
+    expect(ability).to be_able_to(:master_file_download, master_file)
   end
 end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -46,4 +46,22 @@ RSpec.describe AccessToken, type: :model do
       expect(media_object.read_groups).to include(access_token.token)
     end
   end
+  describe 'the active? flag' do
+    let(:access_token) { FactoryBot.create(:access_token) }
+    it 'returns false if the token has expired' do
+      access_token.expiration = 1.day.ago
+      expect(access_token.active?).to be (false)
+    end
+
+    it 'returns false if the token has been revoked' do
+      access_token.revoked = true
+      expect(access_token.active?).to be (false)
+    end
+
+    it 'returns true if not expired and not revoked' do
+      expect(access_token.should_expire?).to be(false)
+      expect(access_token.revoked).to be(false)
+      expect(access_token.active?).to be (true)
+    end
+  end
 end


### PR DESCRIPTION
Added an "active?" flag to "app/models/access_token.rb" AccessToken to easily determine that the token has not expired and not been revoked.

Added handling for an "access_token" request param to the "current_ability" method of "app/controllers/application_controller.rb", so that the parameter gets added as a session option to the current Ability instance.

In "app/models/ability.rb":

* Added an "access_token_download_group_name" method to generate the “allow_download_[MEDIA_OBJECT_ID]” user group from a given media object id
* Added an "access_token_user_groups" method, called from the "user_groups" method, to append the an access token download group, if an active token is provided that allows downloads.
 * Created an "is_master_file_download_allowed?" method that handles all the logic for the "can :master_file_download" permission, to allow downloads when an access_token is active and allows downloads.

Updated the "app/controllers/media_objects_controller.rb" controller and associated "app/views/media_objects/_metadata_display.html.erb" view to add the access token, if present, to the master file download URLs.

https://issues.umd.edu/browse/LIBAVALON-206