### PR TITLE
LIBAVALON-207. Add can_stream permission

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -151,6 +151,10 @@ class ApplicationController < ActionController::Base
   def current_ability
     session_opts ||= user_session
     session_opts ||= {}
+
+    access_token = request.params[:access_token]
+    session_opts = session_opts.merge(access_token: access_token) if access_token
+
     @current_ability ||= Ability.new(current_user, session_opts.merge(remote_ip: request.ip))
   end
 

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -337,9 +337,9 @@ class MediaObjectsController < ApplicationController
   # End customization for LIBAVALON-196
 
   def show
-    @playback_restricted = cannot? :full_read, @media_object
-    @master_file_download_allowed = master_file_download_allowed?
     @access_token = params[:access_token]
+    @playback_restricted = cannot? :stream, @media_object
+    @master_file_download_allowed = master_file_download_allowed?
 
     respond_to do |format|
       format.html do

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -339,6 +339,8 @@ class MediaObjectsController < ApplicationController
   def show
     @playback_restricted = cannot? :full_read, @media_object
     @master_file_download_allowed = master_file_download_allowed?
+    @access_token = params[:access_token]
+
     respond_to do |format|
       format.html do
         if (not @masterFiles.empty? and @currentStream.blank?) then

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -325,7 +325,7 @@ class MediaObjectsController < ApplicationController
 
   # Begin customization for LIBAVALON-196
   def master_file_download_allowed?
-    return false if @masterFiles.empty?
+    return false if @masterFiles.nil? || @masterFiles.empty?
 
     download_allowed = true
     @masterFiles.each do |master_file|

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -24,6 +24,12 @@ class Ability
     can :read, :encode_dashboard if is_administrator?
   end
 
+  def self.access_token_download_group_name(media_object_id)
+    # Returns the group name to use if downloads are allowed for a media object
+    # via an access token
+    "allow_download_#{media_object_id}"
+  end
+
   def user_groups
     return @user_groups if @user_groups
 
@@ -32,7 +38,24 @@ class Ability
     @user_groups |= ['registered'] unless current_user.new_record?
     @user_groups |= @options[:virtual_groups] if @options.present? and @options.has_key? :virtual_groups
     @user_groups |= [@options[:remote_ip]] if @options.present? and @options.has_key? :remote_ip
+
+    if @options.has_key? :access_token
+      token = @options[:access_token]
+      @user_groups |= access_token_user_groups(token)
+    end
+
     @user_groups
+  end
+
+  def access_token_user_groups(token)
+    # Returns a list of the user groups based on the token, or an empty list.
+    return [] if token.nil?
+
+    access_token = AccessToken.find_by(token: token)
+    return [] unless !access_token.nil? && access_token.active? && access_token.allow_download?
+
+    media_object_id = access_token.media_object_id
+    [Ability.access_token_download_group_name(media_object_id)]
   end
 
   def create_permissions(user=nil, session=nil)
@@ -85,9 +108,9 @@ class Ability
 
       # Begin customization for LIBAVALON-196
       can :master_file_download, MasterFile do |master_file|
-        collection = master_file&.media_object&.collection
-        is_member_of?(collection) unless collection.nil?
+        is_master_file_download_allowed?(master_file)
       end
+
       # End customization for LIBAVALON-196
 
       cannot :read, Admin::Collection unless (full_login? || is_api_request?)
@@ -242,6 +265,21 @@ class Ability
   def is_member_of?(collection)
      is_administrator? ||
        @user.in?(collection.managers, collection.editors, collection.depositors)
+  end
+
+  def is_master_file_download_allowed?(master_file)
+    # Returns true if download of the master file is allowed, false otherwise
+    media_object = master_file&.media_object
+    return false unless media_object
+
+    media_object_id = media_object.id
+
+    collection = media_object.collection
+    return false unless collection
+
+    allowed = is_member_of?(collection)
+    allowed = allowed || @user_groups.include?(Ability.access_token_download_group_name(media_object_id))
+    allowed
   end
 
   def is_editor_of?(collection)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -39,7 +39,7 @@ class Ability
     @user_groups |= @options[:virtual_groups] if @options.present? and @options.has_key? :virtual_groups
     @user_groups |= [@options[:remote_ip]] if @options.present? and @options.has_key? :remote_ip
 
-    if @options.has_key? :access_token
+    if @options.present? && @options.has_key?(:access_token)
       token = @options[:access_token]
       @user_groups |= access_token_user_groups(token)
     end

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -22,6 +22,12 @@ class AccessToken < ApplicationRecord
     self.revoked ||= false
   end
 
+  # Returns true if this token has not expired and not revoked, false
+  # otherwise.
+  def active?
+    !should_expire? && !revoked?
+  end
+
   # Checks whether the expiration time for this token is in the past.
   def should_expire?
     self.expiration.past?

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -9,6 +9,21 @@ class AccessToken < ApplicationRecord
   before_save :set_expired_flag
   after_create :add_read_group
 
+  # Convenience method for accessing instance version of "allow_streaming_of?"
+  # with just a token string and media object id
+  def self.allow_streaming_of?(token, media_object_id)
+    access_token = AccessToken.find_by(token: token)
+    return false if access_token.nil?
+
+    access_token.allow_streaming_of?(media_object_id)
+  end
+
+  # Returns true if streaming is allowed by this access token for the given
+  # media object id, false otherwise.
+  def allow_streaming_of?(media_object_id)
+    allow_streaming? && active? && self.media_object_id == media_object_id
+  end
+
   # Generates a URL-safe base64 encoded 12 byte token.
   def generate_token
     self.token ||= Base64.urlsafe_encode64(SecureRandom.random_bytes(12))

--- a/app/views/media_objects/_metadata_display.html.erb
+++ b/app/views/media_objects/_metadata_display.html.erb
@@ -76,7 +76,7 @@ Unless required by applicable law or agreed to in writing, software distributed
         <ul>
         <% @masterFiles.each do |master_file| %>
           <li>
-          <%= link_to(File.basename(master_file.file_location), download_master_file_path(id: master_file.id)) %>
+          <%= link_to(File.basename(master_file.file_location), download_master_file_path(id: master_file.id, access_token: @access_token)) %>
           </li>
         <% end %>
       </div>

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -128,4 +128,17 @@ describe ApplicationController do
       expect(controller.params[:key][:subkey]).to eq "value"
     end
   end
+
+  describe '#current_ability' do
+    it 'adds access_token to session options when "access_token" param is present' do
+      access_token = FactoryBot.create(:access_token)
+      request.params['access_token'] = access_token.token
+      ability = controller.current_ability
+      expect(ability.options[:access_token]).to be(access_token.token)
+    end
+    it 'does not add access_token to session options when "access_token" param is not present' do
+      ability = controller.current_ability
+      expect(ability.options.has_key?(:access_token)).to be(false)
+    end
+  end
 end

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -862,6 +862,24 @@ describe MediaObjectsController, type: :controller do
       end
     end
 
+    context "streaming" do
+      it "should be permitted for when an access token allows streaming" do
+        media_object = FactoryBot.create(:published_media_object, visibility: 'private')
+
+        get :show, params: { id: media_object.id }
+        expect(controller.instance_variable_get('@playback_restricted')).to be true
+
+        # Force reset of current_ability
+        controller.instance_variable_set('@current_ability', nil)
+
+        access_token = FactoryBot.create(:access_token, :allow_streaming, media_object_id: media_object.id)
+        access_token.save!
+
+        get :show, params: { id: media_object.id, access_token: access_token.token }
+        expect(controller.instance_variable_get('@playback_restricted')).to be false
+      end
+    end
+
     context "correctly handle unfound streams/sections" do
       subject(:mo){FactoryBot.create(:media_object, :with_master_file)}
       before do

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -848,10 +848,17 @@ describe MediaObjectsController, type: :controller do
         get :show, params: { id: media_object_with_master_file.id }
         expect(controller.instance_variable_get('@master_file_download_allowed')).to be true
       end
+
       it "should not display when not permitted" do
         login_as :public
         get :show, params: { id: media_object_with_master_file.id }
         expect(controller.instance_variable_get('@master_file_download_allowed')).to be false
+      end
+
+      it "should include @access_token variable for template when access token is provided" do
+        login_as :public
+        get :show, params: { id: media_object_with_master_file.id, access_token: 'test_access_token' }
+        expect(controller.instance_variable_get('@access_token')).to eq 'test_access_token'
       end
     end
 

--- a/spec/factories/access_token.rb
+++ b/spec/factories/access_token.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :access_token, class:AccessToken do
+  factory :access_token do
     association :user
     media_object_id { FactoryBot.create(:media_object).id }
     expiration { 7.days.from_now }

--- a/spec/factories/access_token.rb
+++ b/spec/factories/access_token.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :access_token, class:AccessToken do
+    association :user
+    media_object_id { FactoryBot.create(:media_object).id }
+    expiration { 7.days.from_now }
+  end
+end

--- a/spec/factories/access_token.rb
+++ b/spec/factories/access_token.rb
@@ -3,5 +3,9 @@ FactoryBot.define do
     association :user
     media_object_id { FactoryBot.create(:media_object).id }
     expiration { 7.days.from_now }
+
+    trait :allow_streaming do
+      allow_streaming { true }
+    end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -130,7 +130,7 @@ describe 'masterfile_download Ability' do
     end
   end
 
-  it 'is avaiable if an active access token allowing downloads is provided' do
+  it 'is available if an active access token allowing downloads is provided' do
     access_token = FactoryBot.create(:access_token)
     access_token.media_object_id = master_file.media_object.id
     access_token.allow_download = true

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -21,123 +21,123 @@ describe Ability, type: :model do
       expect(Ability.new(nil).user_groups).to eq ["public"]
     end
   end
-end
 
-describe '#user_groups' do
-  context 'when options has an "access_token" entry' do
-    let (:ability) { Ability.new(nil, { access_token: access_token.token }) }
-    let (:access_token) { FactoryBot.create(:access_token) }
+  describe '#user_groups' do
+    context 'when options has an "access_token" entry' do
+      let (:ability) { Ability.new(nil, { access_token: access_token.token }) }
+      let (:access_token) { FactoryBot.create(:access_token) }
 
-    it 'does not add "allow_download" group if the access token has expired' do
-      access_token.expiration = 1.day.ago
-      access_token.allow_download = true
-      access_token.save!
-      expect(access_token.should_expire?).to be(true)
+      it 'does not add "allow_download" group if the access token has expired' do
+        access_token.expiration = 1.day.ago
+        access_token.allow_download = true
+        access_token.save!
+        expect(access_token.should_expire?).to be(true)
 
-      user_groups = ability.user_groups
-      download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
+        user_groups = ability.user_groups
+        download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
 
-      expect(user_groups.include?(download_group_name)).to be(false)
-    end
+        expect(user_groups.include?(download_group_name)).to be(false)
+      end
 
-    it 'does not add "allow_download" group if the access token has been revoked' do
-      access_token.revoked = true
-      access_token.allow_download = true
-      access_token.save!
-      expect(access_token.revoked?).to be(true)
+      it 'does not add "allow_download" group if the access token has been revoked' do
+        access_token.revoked = true
+        access_token.allow_download = true
+        access_token.save!
+        expect(access_token.revoked?).to be(true)
 
-      user_groups = ability.user_groups
-      download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
+        user_groups = ability.user_groups
+        download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
 
-      expect(user_groups.include?(download_group_name)).to be(false)
-    end
+        expect(user_groups.include?(download_group_name)).to be(false)
+      end
 
-    it 'does not add "allow_download" group if the access token is active but downloads are not allowed' do
-      expect(access_token.active?).to be(true)
-      expect(access_token.allow_download?).to be(false)
+      it 'does not add "allow_download" group if the access token is active but downloads are not allowed' do
+        expect(access_token.active?).to be(true)
+        expect(access_token.allow_download?).to be(false)
 
-      user_groups = ability.user_groups
-      download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
+        user_groups = ability.user_groups
+        download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
 
-      expect(user_groups.include?(download_group_name)).to be(false)
-    end
+        expect(user_groups.include?(download_group_name)).to be(false)
+      end
 
-    it 'does not add "allow_download" group if the access token does not exist' do
-      ability = Ability.new(nil, { access_token: 'does_not_exist' })
+      it 'does not add "allow_download" group if the access token does not exist' do
+        ability = Ability.new(nil, { access_token: 'does_not_exist' })
 
-      user_groups = ability.user_groups
-      download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
+        user_groups = ability.user_groups
+        download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
 
-      expect(user_groups.include?(download_group_name)).to be(false)
-    end
+        expect(user_groups.include?(download_group_name)).to be(false)
+      end
 
-    it 'adds an "allow_download" group if access token is active and allows downloads' do
-      access_token.allow_download = true
-      access_token.save!
-      expect(access_token.active?).to be(true)
-      expect(access_token.allow_download?).to be(true)
+      it 'adds an "allow_download" group if access token is active and allows downloads' do
+        access_token.allow_download = true
+        access_token.save!
+        expect(access_token.active?).to be(true)
+        expect(access_token.allow_download?).to be(true)
 
-      user_groups = ability.user_groups
-      download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
+        user_groups = ability.user_groups
+        download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
 
-      expect(user_groups.include?(download_group_name)).to be(true)
-    end
-  end
-end
-
-describe 'masterfile_download Ability' do
-  let(:published_media_object) { FactoryBot.create(:published_media_object) }
-  let(:master_file) { FactoryBot.create(:master_file, media_object: published_media_object) }
-
-  it 'is not available if master_file does not have associated media_object' do
-    master_file = FactoryBot.create(:master_file)
-    # Need to use "user" instead of "admin", because "admin" skips permissions
-    # check.
-    ability = Ability.new(FactoryBot.create(:user))
-    expect(ability).to_not be_able_to(:master_file_download, master_file)
-  end
-
-  it 'is not available to non-logged in users' do
-    ability = Ability.new(nil)
-    expect(ability).to_not be_able_to(:master_file_download, master_file)
-  end
-
-  it 'is available to admin users' do
-    ability = Ability.new(FactoryBot.create(:admin))
-    expect(ability).to be_able_to(:master_file_download, master_file)
-  end
-
-  it 'is available to managers, editors, and depositors of the collection' do
-    collection_users = master_file.media_object.collection.managers +
-                       master_file.media_object.collection.editors +
-                       master_file.media_object.collection.depositors
-    collection_users.each do |user_name|
-      ability = Ability.new(User.find_by(username: user_name))
-      expect(ability).to be_able_to(:master_file_download, master_file)
+        expect(user_groups.include?(download_group_name)).to be(true)
+      end
     end
   end
 
-  it 'is not available to managers, editors, and depositors of other collections' do
-    other_collection = FactoryBot.create(:collection)
+  describe 'masterfile_download Ability' do
+    let(:published_media_object) { FactoryBot.create(:published_media_object) }
+    let(:master_file) { FactoryBot.create(:master_file, media_object: published_media_object) }
 
-    other_collection_users = other_collection.managers +
-                             other_collection.editors +
-                             other_collection.depositors
-
-    other_collection_users.each do |user_name|
-      ability = Ability.new(User.find_by(username: user_name))
+    it 'is not available if master_file does not have associated media_object' do
+      master_file = FactoryBot.create(:master_file)
+      # Need to use "user" instead of "admin", because "admin" skips permissions
+      # check.
+      ability = Ability.new(FactoryBot.create(:user))
       expect(ability).to_not be_able_to(:master_file_download, master_file)
     end
-  end
 
-  it 'is available if an active access token allowing downloads is provided' do
-    access_token = FactoryBot.create(:access_token)
-    access_token.media_object_id = master_file.media_object.id
-    access_token.allow_download = true
-    access_token.save!
+    it 'is not available to non-logged in users' do
+      ability = Ability.new(nil)
+      expect(ability).to_not be_able_to(:master_file_download, master_file)
+    end
 
-    token = access_token.token
-    ability = Ability.new(nil, { access_token: token })
-    expect(ability).to be_able_to(:master_file_download, master_file)
+    it 'is available to admin users' do
+      ability = Ability.new(FactoryBot.create(:admin))
+      expect(ability).to be_able_to(:master_file_download, master_file)
+    end
+
+    it 'is available to managers, editors, and depositors of the collection' do
+      collection_users = master_file.media_object.collection.managers +
+                        master_file.media_object.collection.editors +
+                        master_file.media_object.collection.depositors
+      collection_users.each do |user_name|
+        ability = Ability.new(User.find_by(username: user_name))
+        expect(ability).to be_able_to(:master_file_download, master_file)
+      end
+    end
+
+    it 'is not available to managers, editors, and depositors of other collections' do
+      other_collection = FactoryBot.create(:collection)
+
+      other_collection_users = other_collection.managers +
+                              other_collection.editors +
+                              other_collection.depositors
+
+      other_collection_users.each do |user_name|
+        ability = Ability.new(User.find_by(username: user_name))
+        expect(ability).to_not be_able_to(:master_file_download, master_file)
+      end
+    end
+
+    it 'is available if an active access token allowing downloads is provided' do
+      access_token = FactoryBot.create(:access_token)
+      access_token.media_object_id = master_file.media_object.id
+      access_token.allow_download = true
+      access_token.save!
+
+      token = access_token.token
+      ability = Ability.new(nil, { access_token: token })
+      expect(ability).to be_able_to(:master_file_download, master_file)
+    end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -23,6 +23,68 @@ describe Ability, type: :model do
   end
 end
 
+describe '#user_groups' do
+  context 'when options has an "access_token" entry' do
+    let (:ability) { Ability.new(nil, { access_token: access_token.token }) }
+    let (:access_token) { FactoryBot.create(:access_token) }
+
+    it 'does not add "allow_download" group if the access token has expired' do
+      access_token.expiration = 1.day.ago
+      access_token.allow_download = true
+      access_token.save!
+      expect(access_token.should_expire?).to be(true)
+
+      user_groups = ability.user_groups
+      download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
+
+      expect(user_groups.include?(download_group_name)).to be(false)
+    end
+
+    it 'does not add "allow_download" group if the access token has been revoked' do
+      access_token.revoked = true
+      access_token.allow_download = true
+      access_token.save!
+      expect(access_token.revoked?).to be(true)
+
+      user_groups = ability.user_groups
+      download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
+
+      expect(user_groups.include?(download_group_name)).to be(false)
+    end
+
+    it 'does not add "allow_download" group if the access token is active but downloads are not allowed' do
+      expect(access_token.active?).to be(true)
+      expect(access_token.allow_download?).to be(false)
+
+      user_groups = ability.user_groups
+      download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
+
+      expect(user_groups.include?(download_group_name)).to be(false)
+    end
+
+    it 'does not add "allow_download" group if the access token does not exist' do
+      ability = Ability.new(nil, { access_token: 'does_not_exist' })
+
+      user_groups = ability.user_groups
+      download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
+
+      expect(user_groups.include?(download_group_name)).to be(false)
+    end
+
+    it 'adds an "allow_download" group if access token is active and allows downloads' do
+      access_token.allow_download = true
+      access_token.save!
+      expect(access_token.active?).to be(true)
+      expect(access_token.allow_download?).to be(true)
+
+      user_groups = ability.user_groups
+      download_group_name = Ability.access_token_download_group_name(access_token.media_object_id)
+
+      expect(user_groups.include?(download_group_name)).to be(true)
+    end
+  end
+end
+
 describe 'masterfile_download Ability' do
   let(:published_media_object) { FactoryBot.create(:published_media_object) }
   let(:master_file) { FactoryBot.create(:master_file, media_object: published_media_object) }
@@ -56,7 +118,7 @@ describe 'masterfile_download Ability' do
   end
 
   it 'is not available to managers, editors, and depositors of other collections' do
-    other_collection = FactoryBot.build(:collection)
+    other_collection = FactoryBot.create(:collection)
 
     other_collection_users = other_collection.managers +
                              other_collection.editors +
@@ -66,5 +128,16 @@ describe 'masterfile_download Ability' do
       ability = Ability.new(User.find_by(username: user_name))
       expect(ability).to_not be_able_to(:master_file_download, master_file)
     end
+  end
+
+  it 'is avaiable if an active access token allowing downloads is provided' do
+    access_token = FactoryBot.create(:access_token)
+    access_token.media_object_id = master_file.media_object.id
+    access_token.allow_download = true
+    access_token.save!
+
+    token = access_token.token
+    ability = Ability.new(nil, { access_token: token })
+    expect(ability).to be_able_to(:master_file_download, master_file)
   end
 end

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -46,4 +46,22 @@ RSpec.describe AccessToken, type: :model do
       expect(media_object.read_groups).to include(access_token.token)
     end
   end
+  describe 'the active? flag' do
+    let(:access_token) { FactoryBot.create(:access_token) }
+    it 'returns false if the token has expired' do
+      access_token.expiration = 1.day.ago
+      expect(access_token.active?).to be (false)
+    end
+
+    it 'returns false if the token has been revoked' do
+      access_token.revoked = true
+      expect(access_token.active?).to be (false)
+    end
+
+    it 'returns true if not expired and not revoked' do
+      expect(access_token.should_expire?).to be(false)
+      expect(access_token.revoked).to be(false)
+      expect(access_token.active?).to be (true)
+    end
+  end
 end


### PR DESCRIPTION
Add token based access control to stream a media file that a user would otherwise not be able to access.

Added "allow_streaming_of?" methods to AccessToken to determine if streaming is allowed for a particular token and media object.

In "app/models/ability.rb" added "can stream?" and "is_streaming_allowed?" methods to control whether streaming is allowed. Kept existing behavior to allow streaming if "can? full_read" is permitted, and added additional override to permit streaming if "AccessToken.allow_streaming_of?" returns true.

Modified "app/controllers/media_objects_controller.rb" to use the new streaming ability.

In "spec/models/ability_spec.rb", moved "#user_groups", and "masterfile_download Ability" tests underneath the overarching "Ability" description, so that the RSpec documentation would be more correct.

https://issues.umd.edu/browse/LIBAVALON-207