### PR TITLE
LIBAVALON-213. Added a Download button to the media object detail page

### DIFF
--- a/app/assets/stylesheets/avalon/_buttons.scss
+++ b/app/assets/stylesheets/avalon/_buttons.scss
@@ -42,3 +42,16 @@ button.close {
     text-decoration: none;
   }
 }
+
+#download-button {
+  text-align: right;
+  margin-top: 10px;
+  margin-bottom: 0;
+
+  a:link,
+  a:visited,
+  a:hover,
+  a:active {
+    text-decoration: none;
+  }
+}

--- a/app/views/media_objects/_download.html.erb
+++ b/app/views/media_objects/_download.html.erb
@@ -1,0 +1,28 @@
+<% unless @masterFiles.nil? || @masterFiles.empty? ||  !@master_file_download_allowed %>
+  <div id="download-button-block" style="display: inline-block;">
+    <button type="button" class="btn btn-default" id="download-button" data-toggle="modal" data-target="#downloadModal">
+      <i class="fa fa-download" style="color: #2a5459"></i>
+      Download
+    </button>
+  </div>
+
+  <div class="modal fade" id="downloadModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true" style="display: none;">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="downloadModalLabel">Download</h5>
+        </div>
+        <div class="modal-body">
+          <ul>
+            <% @masterFiles.each do |master_file| %>
+              <li><%= link_to(File.basename(master_file.file_location), download_master_file_path(id: master_file.id, access_token: @access_token)) %></li>
+            <% end %>
+          </ul>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -51,6 +51,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     <%= render 'workflow_progress' %>
     <%= render partial: 'timeline' if current_ability.can? :create, Timeline %>
     <% end %>
+    <%= render 'download' if @master_file_download_allowed %>
     <%= render 'share' if will_partial_list_render? :share %>
     <% unless @playback_restricted %>
 


### PR DESCRIPTION
Added a "Download" button next to the "Share" button on the media object
detail page.

Note: The "Download" button is placed to the left of the "Share" button,
(not to the right, as suggested in the issue description), because
left-clicking the "Share" button displays a tabbed panel. If the
"Download" button were placed to the right, the "Download" button
would be displaced to underneath the opened panel. It was not
immediately obvious how to correct this, so simply moved the
"Download" button to the left of the "Share" button.

Left-clicking "Download" button opens up a modal dialog, which shows a
bulleted list of the available downloads. This is to handle the
(potential) case of a media object have multiple master files to
download, and is similar in appearance to the "Downloads" panel in the
right sidebar.

The "Download" button functionality is provided in the
"app/views/media_objects/_download.html.erb" helper file, and is
configured to display only if there are one or more masterfiles, and
master file downloads are allowed.

The "app/views/media_objects/_item_view.html.erb" helper file was
modified to place the "Download" button only if master file downloads
are allowed.

Added CSS configuration for the "Download" button to the
"app/assets/stylesheets/avalon/_buttons.scss" file, following the
example of the "Share" button.

https://issues.umd.edu/browse/LIBAVALON-213