### PR TITLE
LIBAVALON-216. Authorization rules for AccessTokens

### DIFF
--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -89,7 +89,15 @@ class AccessTokensController < ApplicationController
     end
 
     def access_tokens_list(status)
-      AccessToken.send(status).order(:expiration).page(params[:page])
+      tokens = AccessToken.with_status(status).order(:expiration)
+      if cannot? :list_all, AccessToken
+        # filter to only those tokens for which the current user is an editor
+        # we cannot do this in the database only, so we have to paginate the array
+        # instead of the ActiveRecord::Relation
+        tokens = tokens.to_a.select {|token| current_ability.is_editor_of?(token.media_object.collection)}
+        tokens = Kaminari.paginate_array(tokens)
+      end
+      tokens.page(params[:page])
     end
 
     def access_token_params

--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -91,10 +91,10 @@ class AccessTokensController < ApplicationController
     def access_tokens_list(status)
       tokens = AccessToken.with_status(status).order(:expiration)
       if cannot? :list_all, AccessToken
-        # filter to only those tokens for which the current user is an editor
+        # filter to only those tokens for which the current user is a collection member
         # we cannot do this in the database only, so we have to paginate the array
         # instead of the ActiveRecord::Relation
-        tokens = tokens.to_a.select {|token| current_ability.is_editor_of?(token.media_object.collection)}
+        tokens = tokens.to_a.select {|token| current_ability.is_member_of?(token.media_object.collection)}
         tokens = Kaminari.paginate_array(tokens)
       end
       tokens.page(params[:page])

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -117,6 +117,12 @@ class Ability
 
       # End customization for LIBAVALON-196
 
+      can [:create, :update], AccessToken do |access_token|
+        is_editor_of?(access_token.media_object.collection)
+      end
+
+      can :list_all, AccessToken if is_administrator?
+
       cannot :read, Admin::Collection unless (full_login? || is_api_request?)
 
       if full_login? || is_api_request?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -118,7 +118,7 @@ class Ability
       # End customization for LIBAVALON-196
 
       can [:create, :update], AccessToken do |access_token|
-        is_editor_of?(access_token.media_object.collection)
+        is_member_of?(access_token.media_object.collection)
       end
 
       can :list_all, AccessToken if is_administrator?

--- a/spec/controllers/access_tokens_controller_spec.rb
+++ b/spec/controllers/access_tokens_controller_spec.rb
@@ -97,8 +97,8 @@ RSpec.describe AccessTokensController, type: :controller do
 
   context '#show' do
     it 'provides a link to the Media Object Access Control page' do
-      login_as(:administrator)
-      access_token = FactoryBot.create(:access_token)
+      user = login_as(:administrator)
+      access_token = FactoryBot.create(:access_token, user: user)
 
       get :show, params: { id: access_token.id }
 
@@ -108,8 +108,8 @@ RSpec.describe AccessTokensController, type: :controller do
 
     context 'for active tokens' do
       it 'includes a text snippet containing information to provide to the patron' do
-        login_as(:administrator)
-        access_token = FactoryBot.create(:access_token)
+        user = login_as(:administrator)
+        access_token = FactoryBot.create(:access_token, user: user)
 
         get :show, params: { id: access_token.id }
         expect(controller.instance_variable_get('@info_for_patron_snippet')).to_not be_empty
@@ -117,8 +117,8 @@ RSpec.describe AccessTokensController, type: :controller do
     end
     context 'for expired or revoked tokens' do
       it 'does not include a text snippet containing information to provide to the patron' do
-        login_as(:administrator)
-        access_token = FactoryBot.create(:access_token, expiration: 30.minutes.from_now)
+        user = login_as(:administrator)
+        access_token = FactoryBot.create(:access_token, expiration: 30.minutes.from_now, user: user)
 
         # Expired token
         travel_to(1.hour.from_now) do
@@ -137,8 +137,8 @@ RSpec.describe AccessTokensController, type: :controller do
 
   context '#edit' do
     it 'provides a Cancel link back to the "show" access page' do
-      login_as(:administrator)
-      access_token = FactoryBot.create(:access_token)
+      user = login_as(:administrator)
+      access_token = FactoryBot.create(:access_token, user: user)
 
       get :edit, params: { id: access_token.id }
       cancel_link = controller.instance_variable_get('@cancel_link')

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -132,7 +132,7 @@ describe ApplicationController do
   describe '#current_ability' do
     it 'adds access_token to session options when "access_token" param is present' do
       access_token = FactoryBot.create(:access_token)
-      request.params['access_token'] = access_token.token
+      request.query_parameters['access_token'] = access_token.token
       ability = controller.current_ability
       expect(ability.options[:access_token]).to be(access_token.token)
     end

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -634,13 +634,13 @@ describe MediaObjectsController, type: :controller do
 
     it "should display active Access Tokens" do
       media_object = FactoryBot.create(:media_object)
-      login_user media_object.collection.managers.first
+      user = login_user media_object.collection.managers.first
 
       # When no access tokens, count should be zero
       get 'edit', params: { id: media_object.id, step: 'access-control' }
       expect(controller.instance_variable_get('@active_access_tokens').count).to eq(0)
 
-      access_token = FactoryBot.create(:access_token, :allow_streaming, media_object_id: media_object.id)
+      access_token = FactoryBot.create(:access_token, :allow_streaming, media_object_id: media_object.id, user: user)
 
       # When active access token exists, should be returned.
       get 'edit', params: { id: media_object.id, step: 'access-control' }
@@ -880,6 +880,7 @@ describe MediaObjectsController, type: :controller do
     context "streaming" do
       it "should be permitted for when an access token allows streaming" do
         media_object = FactoryBot.create(:published_media_object, visibility: 'private')
+        user = login_user media_object.collection.managers.first
 
         get :show, params: { id: media_object.id }
         expect(controller.instance_variable_get('@playback_restricted')).to be true
@@ -887,7 +888,7 @@ describe MediaObjectsController, type: :controller do
         # Force reset of current_ability
         controller.instance_variable_set('@current_ability', nil)
 
-        access_token = FactoryBot.create(:access_token, :allow_streaming, media_object_id: media_object.id)
+        access_token = FactoryBot.create(:access_token, :allow_streaming, media_object_id: media_object.id, user: user)
         access_token.save!
 
         get :show, params: { id: media_object.id, access_token: access_token.token }

--- a/spec/factories/access_token.rb
+++ b/spec/factories/access_token.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :access_token do
-    association :user
+    # Have an admin user by default, so token will be valid for any media object
+    association :user, factory: :admin
     media_object_id { FactoryBot.create(:media_object).id }
     expiration { 7.days.from_now }
 

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -32,10 +32,43 @@ FactoryBot.define do
     end
 
     trait :with_poster do
-      after(:create) do |collection|
+      after(:build) do |collection|
         collection.poster.mime_type = 'image/png'
         collection.poster.content = 'fake image content'
         collection.save
+      end
+    end
+
+    trait :with_manager do
+      transient do
+        manager {nil}
+      end
+      after(:build) do |collection, evaluator|
+        if evaluator.manager.present?
+          collection.add_manager(evaluator.manager.user_key)
+        end
+      end
+    end
+
+    trait :with_editor do
+      transient do
+        editor {nil}
+      end
+      after(:build) do |collection, evaluator|
+        if evaluator.editor.present?
+          collection.add_editor(evaluator.editor.user_key)
+        end
+      end
+    end
+
+    trait :with_depositor do
+      transient do
+        depositor {nil}
+      end
+      after(:build) do |collection, evaluator|
+        if evaluator.depositor.present?
+          collection.add_depositor(evaluator.depositor.user_key)
+        end
       end
     end
   end


### PR DESCRIPTION
This pull request replaces Pull Request #99

* Must be an admin or  collection member (manager, editor, depositor) to create or update its access tokens for a media object.
* If a user doesn't have permission to create or update an access token, return a "media object not found" error to prevent leaking information about which media objects do exist
* Added a list_all AccessToken ability for administrators; collection members can only see tokens for objects in collections they have access to

https://issues.umd.edu/browse/LIBAVALON-216
