### PR TITLE
LIBAVALON-226. Create button that directly takes user to access token list

### DIFF
--- a/app/controllers/access_tokens_controller.rb
+++ b/app/controllers/access_tokens_controller.rb
@@ -1,5 +1,6 @@
 class AccessTokensController < ApplicationController
   before_action :authenticate_user!
+  before_action :auth
 
   STATUS_VALUES = %w[active expired revoked all]
 
@@ -8,6 +9,10 @@ class AccessTokensController < ApplicationController
     'Download Only' => :download_only,
     'Streaming and Download' => :streaming_and_download,
   }
+
+  def auth
+    authorize! :manage, AccessToken
+  end
 
   def index
     @show_status = status_value

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -123,6 +123,8 @@ class Ability
 
       can :list_all, AccessToken if is_administrator?
 
+      can :manage, AccessToken if (is_member_of_any_collection? or @user_groups.include? 'manager')
+
       cannot :read, Admin::Collection unless (full_login? || is_api_request?)
 
       if full_login? || is_api_request?

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -48,6 +48,10 @@ Unless required by applicable law or agreed to in writing, software distributed
           Manage
         </button>
         <ul class="dropdown-menu nav navbar-default navbar-nav manage-dropdown-menu">
+          <% if can? :manage, AccessToken %>
+          <li class=<%= active_for_controller('access_tokens') %>>
+            <%= link_to 'Manage Access Tokens', main_app.access_tokens_path %></li>
+          <% end %>
           <% if can? :read, Admin::Collection %>
           <li class=<%= active_for_controller('admin/collections') %>>
             <%= link_to 'Manage Content', main_app.admin_collections_path %></li>

--- a/app/views/access_tokens/index.html.erb
+++ b/app/views/access_tokens/index.html.erb
@@ -1,3 +1,5 @@
+<h1>Access Tokens</h1>
+
 <form method="get">
   <strong>Showing <%= @show_status %> tokens.</strong>
   Filter by status:

--- a/spec/features/capybara_navigation_spec.rb
+++ b/spec/features/capybara_navigation_spec.rb
@@ -51,6 +51,52 @@ describe 'checks navigation after logging in' do
     expect(page).to have_content('administrator')
     expect(page).to have_content('manager')
   end
+  context 'checks navigation to Manage Access Tokens' do
+    it 'displayed for administrators' do
+      user = FactoryBot.create(:administrator)
+      login_as user, scope: :user
+      visit '/'
+      click_link('Manage Access Tokens')
+      expect(page.current_url).to eq('http://www.example.com/access_tokens')
+      expect(page).to have_content('Access')
+      expect(page).to have_content('Create a new token')
+    end
+    it 'displayed for managers' do
+      user = FactoryBot.create(:manager)
+      login_as user, scope: :user
+      visit '/'
+      click_link('Manage Access Tokens')
+      expect(page.current_url).to eq('http://www.example.com/access_tokens')
+      expect(page).to have_content('Access')
+      expect(page).to have_content('Create a new token')
+    end
+    it 'displayed for editors' do
+      user = FactoryBot.create(:user)
+      collection = FactoryBot.create(:collection, :with_editor, editor: user)
+      login_as user, scope: :user
+      visit '/'
+      click_link('Manage Access Tokens')
+      expect(page.current_url).to eq('http://www.example.com/access_tokens')
+      expect(page).to have_content('Access')
+      expect(page).to have_content('Create a new token')
+    end
+    it 'displayed for depositors' do
+      user = FactoryBot.create(:user)
+      collection = FactoryBot.create(:collection, :with_depositor, depositor: user)
+      login_as user, scope: :user
+      visit '/'
+      click_link('Manage Access Tokens')
+      expect(page.current_url).to eq('http://www.example.com/access_tokens')
+      expect(page).to have_content('Access')
+      expect(page).to have_content('Create a new token')
+    end
+    it 'is not displayed for other users' do
+      user = FactoryBot.create(:user)
+      login_as user, scope: :user
+      visit '/'
+      expect(page).to have_no_link('Manage Access Tokens')
+    end
+  end
   it 'checks naviagtion to Playlist' do
     user = FactoryBot.create(:administrator)
     login_as user, scope: :user


### PR DESCRIPTION
Two related changes were implemented as part of this issue:

## Display "Manage Access Tokens" entry in navigation bar

Added "Manage Access Tokens" entry in the "Manage" dropdown on the navigation bar. Placed the entry first, so that the items in the dropdown would be in alphabetical order.

Added an AccessToken "manage" ability to "models/ability.rb", and restricted display of the "Manage Access Tokens" entry to users that have the AccessToken "manage" ability, which should be administrators (which can "manage" anything), or users that are managers, editors, or depositors of any collection.

Also, added an "Access Tokens" header to the access tokens "index" page, to be consistent with other Avalon pages.

## Restrict access token endpoints based on "manage" ability

While working on this issue it was noticed that access token endpoints are accessible (via a direct URL) to any authenticated user. This includes "show" page of individual tokens, if they can guess the URL (which are easily guessable, as the database id is used to specify the access token page, i.e. http://av-local:3000/access_tokens/1)

Added an "auth" method to "app/controllers/access_tokens_controller.rb" to restrict access to users having the AccessToken "manage" ability.

https://issues.umd.edu/browse/LIBAVALON-226