### PR TITLE
LIBAVALON-263. Implemented UmdIPManager service.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,6 +105,9 @@ gem 'with_locking'
 # Health Check
 gem 'health_check'
 
+# for UMD IP Manager API
+gem 'faraday_json'
+
 group :development do
   gem 'capistrano', '~>3.6'
   gem 'capistrano-passenger', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1294,6 +1294,8 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-encoding (0.0.4)
       faraday
+    faraday_json (0.1.4)
+      faraday (~> 0.10)
     fastimage (2.1.7)
     fcrepo_wrapper (0.9.0)
       ruby-progressbar
@@ -1868,6 +1870,7 @@ DEPENDENCIES
   factory_bot_rails
   fakefs
   faker
+  faraday_json
   fastimage
   fcrepo_wrapper
   fedora-migrate!

--- a/app/models/lease.rb
+++ b/app/models/lease.rb
@@ -28,6 +28,7 @@ class Lease < ActiveFedora::Base
   scope :user,     -> { where(lease_type_ssi: "user")     }
   scope :external, -> { where(lease_type_ssi: "external") }
   scope :ip,       -> { where(lease_type_ssi: "ip")       }
+  scope :umd_ip_manager, -> { where(lease_type_ssi: "umd_ip_manager") }
 
   before_save :apply_default_begin_time, :ensure_end_time_present, :validate_dates#, :format_times
 
@@ -158,6 +159,7 @@ private
     return nil if group.nil?
     return "ip" if IPAddr.new(group) rescue false
     return "local" if Admin::Group.exists? group
+    return "umd_ip_manager" if UmdIPManager::Group.valid_prefixed_key?(group)
     return "external"
   end
 

--- a/app/services/umd_ip_manager.rb
+++ b/app/services/umd_ip_manager.rb
@@ -44,14 +44,23 @@ class UmdIPManager
       @prefixed_key = Group.as_prefixed_key(base_key)
     end
 
+    # Returns the prefixed key for the given base key.
     def self.as_prefixed_key(base_key)
       raise ArgumentError, "invalid argument: base_key='#{base_key}'" unless base_key.present?
       "#{PREFIX}#{base_key}"
     end
 
+    # Returns the base key for the given prefixed key.
     def self.as_base_key(prefixed_key)
       raise ArgumentError, 'prefixed_key does not start with expected prefix' unless prefixed_key&.starts_with?(PREFIX)
       prefixed_key.delete_prefix(PREFIX)
+    end
+
+    # Returns true if the given prefixed_key is a valid prefixed key, false
+    # otherwise
+    def self.valid_prefixed_key?(prefixed_key)
+      return false if prefixed_key.nil?
+      prefixed_key.starts_with?(PREFIX)
     end
   end
 
@@ -63,6 +72,7 @@ class UmdIPManager
       @errors = errors
     end
 
+    # Returns true if no errors occurred, false otherwise.
     def success?
       @errors.empty?
     end

--- a/app/services/umd_ip_manager.rb
+++ b/app/services/umd_ip_manager.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+class UmdIPManager
+  GROUP_PREFIX = 'umd.ip.manager:'
+
+  def groups
+    groups = retrieve_groups
+    GroupsResult.new(groups: groups)
+  rescue StandardError => e
+    GroupsResult.new(errors: [e.message])
+  end
+
+  def check_ip(group_base_key:, ip_address:)
+    raise ArgumentError, "invalid argument: group_base_key='#{group_base_key}'" unless group_base_key.present?
+    raise ArgumentError, "invalid argument: ip_address='#{ip_address}'" unless ip_address.present?
+
+    begin
+      ip_is_member = do_check_ip(group_base_key: group_base_key, ip_address: ip_address)
+      CheckIPResult.new(ip_is_member: ip_is_member)
+    rescue StandardError => e
+      CheckIPResult.new(errors: [e.message])
+    end
+  end
+
+  def retrieve_groups
+    # TODO - returns an array of UmdIPManager::Group, or raises an exception
+  end
+
+  def do_check_ip(group_base_key:, ip_address:)
+    # TODO - returns true, if the given IP Address is in the given group,
+    # false otherwise. Raise an exception if an error occurs
+  end
+
+  class Group
+    PREFIX = UmdIPManager::GROUP_PREFIX
+
+    attr_reader :base_key, :prefixed_key, :name
+
+    def initialize(base_key:, name:)
+      raise ArgumentError, "invalid argument: base_key='#{base_key}'" unless base_key.present?
+      raise ArgumentError, "invalid argument: name='#{name}'" unless name.present?
+      @base_key = base_key
+      @name = name
+      @prefixed_key = Group.as_prefixed_key(base_key)
+    end
+
+    def self.as_prefixed_key(base_key)
+      raise ArgumentError, "invalid argument: base_key='#{base_key}'" unless base_key.present?
+      "#{PREFIX}#{base_key}"
+    end
+
+    def self.as_base_key(prefixed_key)
+      raise ArgumentError, 'prefixed_key does not start with expected prefix' unless prefixed_key&.starts_with?(PREFIX)
+      prefixed_key.delete_prefix(PREFIX)
+    end
+  end
+
+  class GroupsResult
+    attr_reader :groups, :errors
+
+    def initialize(groups: [], errors: [])
+      @groups = groups
+      @errors = errors
+    end
+
+    def success?
+      @errors.empty?
+    end
+  end
+
+  class CheckIPResult
+    attr_reader :errors
+
+    def initialize(ip_is_member: false, errors: [])
+      @ip_is_member = ip_is_member
+      @errors = errors
+    end
+
+    def ip_is_member?
+      @ip_is_member
+    end
+
+    def success?
+      @errors.empty?
+    end
+  end
+end

--- a/spec/models/lease_spec.rb
+++ b/spec/models/lease_spec.rb
@@ -195,6 +195,13 @@ describe Lease do
       }.to change{Lease.ip.count}.by(1)
       expect(lease.lease_type).to eq "ip"
     end
+    it 'identifies UMD IP Manager lease_type' do
+      expect {
+        lease.inherited_read_groups = [UmdIPManager::Group.as_prefixed_key('test')]
+        lease.save
+      }.to change{Lease.umd_ip_manager.count}.by(1)
+      expect(lease.lease_type).to eq "umd_ip_manager"
+    end
   end
   describe '#media_objects' do
     let(:media_object) { FactoryBot.create(:media_object) }

--- a/spec/services/umd_ip_manager_spec.rb
+++ b/spec/services/umd_ip_manager_spec.rb
@@ -114,6 +114,8 @@ describe UmdIPManager::GroupsResult do
 end
 
 describe UmdIPManager::Group do
+  EXPECTED_PREFIX = 'umd.ip.manager:'
+
   it 'provides the base_key for a group' do
     group = described_class.new(base_key: 'test-base-key', name: 'Test')
     expect(group.base_key).to eq('test-base-key')
@@ -121,7 +123,7 @@ describe UmdIPManager::Group do
 
   it 'provides the prefixed_key for a group' do
     group = described_class.new(base_key: 'test-base-key', name: 'Test')
-    expect(group.prefixed_key).to eq('umd.ip.manager:test-base-key')
+    expect(group.prefixed_key).to eq("#{EXPECTED_PREFIX}test-base-key")
   end
 
   it 'provides the name of the group' do
@@ -143,7 +145,7 @@ describe UmdIPManager::Group do
       group = described_class.new(base_key: 'test-base-key', name: 'Test')
       expect(group.base_key).to eq('test-base-key')
       expect(group.name).to eq('Test')
-      expect(group.prefixed_key).to eq('umd.ip.manager:test-base-key')
+      expect(group.prefixed_key).to eq("#{EXPECTED_PREFIX}test-base-key")
     end
   end
 
@@ -163,7 +165,7 @@ describe UmdIPManager::Group do
     end
 
     it 'returns the given base_key prefixed with UmdIPManager::Group.PREFIX' do
-      expect(described_class.as_prefixed_key('foo')).to eq('umd.ip.manager:foo')
+      expect(described_class.as_prefixed_key('foo')).to eq("#{EXPECTED_PREFIX}foo")
     end
   end
 
@@ -177,17 +179,37 @@ describe UmdIPManager::Group do
         expect { described_class.as_base_key('') }.to raise_error(ArgumentError)
       end
 
-      it 'when given an prefixed_key of only whitespace' do
+      it 'when given a prefixed_key of only whitespace' do
         expect { described_class.as_base_key("  \t  ") }.to raise_error(ArgumentError)
       end
 
-      it 'when given an prefixed_key without the expected prefix' do
+      it 'when given a prefixed_key without the expected prefix' do
         expect { described_class.as_base_key("UNEXPECTED_PREFIX") }.to raise_error(ArgumentError)
       end
     end
 
     it 'returns the given prefixed_key without the UmdIPManager::Group.PREFIX' do
-      expect(described_class.as_base_key('umd.ip.manager:foo')).to eq('foo')
+      expect(described_class.as_base_key("#{EXPECTED_PREFIX}foo")).to eq('foo')
+    end
+  end
+
+  context '.valid_prefixed_key?' do
+    context 'return false' do
+      it 'when given a nil prefixed_key' do
+        expect(described_class.valid_prefixed_key?(nil)).to be(false)
+      end
+
+      it 'when given an empty prefixed_key' do
+        expect(described_class.valid_prefixed_key?('')).to be(false)
+      end
+
+      it 'when given a prefixed_key without the expected prefix' do
+        expect(described_class.valid_prefixed_key?("UNEXPECTED_PREFIX:test")).to be(false)
+      end
+    end
+
+    it 'returns true when given prefixed_key with the expected prefix' do
+      expect(described_class.valid_prefixed_key?("#{EXPECTED_PREFIX}foo")).to be(true)
     end
   end
 end

--- a/spec/services/umd_ip_manager_spec.rb
+++ b/spec/services/umd_ip_manager_spec.rb
@@ -1,0 +1,193 @@
+require 'rails_helper'
+
+describe UmdIPManager do
+  let(:ip_manager) { described_class.new }
+
+  context '#groups' do
+    it 'returns a GroupsResult with a list of UmdIPManager::Groups on success' do
+      test_group = UmdIPManager::Group.new(base_key: 'test-group', name: 'Test Group')
+      allow(ip_manager).to receive(:retrieve_groups) {
+        [test_group]
+      }
+
+      groups_result = ip_manager.groups
+
+      expect(groups_result.success?).to be(true)
+      expect(groups_result.groups).to contain_exactly(test_group)
+    end
+
+    it 'returns a GroupsResult with errors on failure' do
+      allow(ip_manager).to receive(:retrieve_groups) { raise StandardError, "An error occurred" }
+
+      groups_result = ip_manager.groups
+      expect(groups_result.success?).to be(false)
+    end
+  end
+
+  context '#check_ip' do
+    it 'raises an ArgumentError when given invalid parameters' do
+      expect { ip_manager.check_ip }.to raise_error(ArgumentError)
+      expect { ip_manager.check_ip(group_base_key: '') }.to raise_error(ArgumentError)
+      expect { ip_manager.check_ip(ip_address: '') }.to raise_error(ArgumentError)
+      expect { ip_manager.check_ip(group_base_key: '', ip_address: '') }.to raise_error(ArgumentError)
+    end
+
+    it 'returns a successful CheckIPResult indicating whether an IP is a member when no errors occur' do
+      allow(ip_manager).to receive(:do_check_ip).with(group_base_key: 'test_localhost', ip_address: '127.0.0.1').and_return(true)
+      allow(ip_manager).to receive(:do_check_ip).with(group_base_key: 'test_localhost', ip_address: '192.168.1.105').and_return(false)
+
+      check_ip_result = ip_manager.check_ip(group_base_key: 'test_localhost', ip_address: '127.0.0.1')
+      expect(check_ip_result.success?).to be(true)
+      expect(check_ip_result.ip_is_member?).to be(true)
+
+      check_ip_result = ip_manager.check_ip(group_base_key: 'test_localhost', ip_address: '192.168.1.105')
+      expect(check_ip_result.success?).to be(true)
+      expect(check_ip_result.ip_is_member?).to be(false)
+    end
+
+    it 'returns a CheckIPResult with errors on failure' do
+      allow(ip_manager).to receive(:do_check_ip) { raise StandardError, "An error occurred" }
+
+      check_ip_result = ip_manager.check_ip(group_base_key: 'test_localhost', ip_address: '127.0.0.1')
+      expect(check_ip_result.success?).to be(false)
+      expect(check_ip_result.ip_is_member?).to be(false)
+      expect(check_ip_result.errors.length).to eq(1)
+    end
+  end
+end
+
+describe UmdIPManager::CheckIPResult do
+  context '#success?' do
+    it 'returns true when there are no errors' do
+      check_ip_result = described_class.new
+      expect(check_ip_result.success?).to be(true)
+      expect(check_ip_result.errors.length).to eq(0)
+    end
+
+    it 'returns false when there are errors' do
+      check_ip_result = described_class.new(errors: ['An error occurred!'])
+      expect(check_ip_result.success?).to be(false)
+      expect(check_ip_result.errors.length).to eq(1)
+    end
+  end
+
+  it 'returns true when an IP Address is a member of the group' do
+    check_ip_result = described_class.new(ip_is_member: true)
+    expect(check_ip_result.ip_is_member?).to be(true)
+  end
+
+  it 'returns false when an IP Address is not a member of the group' do
+    check_ip_result = described_class.new(ip_is_member: false)
+    expect(check_ip_result.ip_is_member?).to be(false)
+  end
+end
+
+describe UmdIPManager::GroupsResult do
+  context '#success?' do
+    it 'returns true when there are no errors' do
+      groups_result = described_class.new
+      expect(groups_result.success?).to be(true)
+      expect(groups_result.errors.length).to eq(0)
+    end
+
+    it 'returns false when there are errors' do
+      groups_result = described_class.new(errors: ['An error occurred!'])
+      expect(groups_result.success?).to be(false)
+      expect(groups_result.errors.length).to eq(1)
+    end
+  end
+
+  it 'returns a list of provided groups' do
+    group1 = UmdIPManager::Group.new(base_key: 'group-1', name: 'Group 1')
+    group2 = UmdIPManager::Group.new(base_key: 'group-2', name: 'Group 2')
+    groups = [group1, group2]
+
+    groups_result = described_class.new(groups: groups)
+    expect(groups_result.groups).to contain_exactly(group1, group2)
+  end
+
+  it 'may return an empty list of groups' do
+    groups_result = described_class.new
+    expect(groups_result.groups).to be_empty
+    expect(groups_result.success?).to be(true)
+  end
+end
+
+describe UmdIPManager::Group do
+  it 'provides the base_key for a group' do
+    group = described_class.new(base_key: 'test-base-key', name: 'Test')
+    expect(group.base_key).to eq('test-base-key')
+  end
+
+  it 'provides the prefixed_key for a group' do
+    group = described_class.new(base_key: 'test-base-key', name: 'Test')
+    expect(group.prefixed_key).to eq('umd.ip.manager:test-base-key')
+  end
+
+  it 'provides the name of the group' do
+    group = described_class.new(base_key: 'test-base-key', name: 'Test')
+    expect(group.name).to eq('Test')
+  end
+
+  context '#initialize' do
+    it 'raises an ArgumentError when given invalid parameters' do
+      expect { described_class.new }.to raise_error(ArgumentError)
+      expect { described_class.new(name: '') }.to raise_error(ArgumentError)
+      expect { described_class.new(base_key: '') }.to raise_error(ArgumentError)
+      expect { described_class.new(base_key: '', name: '') }.to raise_error(ArgumentError)
+      expect { described_class.new(base_key: 'foo', name: '') }.to raise_error(ArgumentError)
+      expect { described_class.new(base_key: '', name: 'Foo') }.to raise_error(ArgumentError)
+    end
+
+    it 'is properly constructed when given valid parameters' do
+      group = described_class.new(base_key: 'test-base-key', name: 'Test')
+      expect(group.base_key).to eq('test-base-key')
+      expect(group.name).to eq('Test')
+      expect(group.prefixed_key).to eq('umd.ip.manager:test-base-key')
+    end
+  end
+
+  context '.as_prefixed_key' do
+    context 'raises an ArgumentError' do
+      it 'when given a nil base_key' do
+        expect { described_class.as_prefixed_key(nil) }.to raise_error(ArgumentError)
+      end
+
+      it 'when given an empty base_key' do
+        expect { described_class.as_prefixed_key('') }.to raise_error(ArgumentError)
+      end
+
+      it 'when given an base_key of only whitespace' do
+        expect { described_class.as_prefixed_key("  \t  ") }.to raise_error(ArgumentError)
+      end
+    end
+
+    it 'returns the given base_key prefixed with UmdIPManager::Group.PREFIX' do
+      expect(described_class.as_prefixed_key('foo')).to eq('umd.ip.manager:foo')
+    end
+  end
+
+  context '.as_base_key' do
+    context 'raises an ArgumentError' do
+      it 'when given a nil prefixed_key' do
+        expect { described_class.as_base_key(nil) }.to raise_error(ArgumentError)
+      end
+
+      it 'when given an empty prefixed_key' do
+        expect { described_class.as_base_key('') }.to raise_error(ArgumentError)
+      end
+
+      it 'when given an prefixed_key of only whitespace' do
+        expect { described_class.as_base_key("  \t  ") }.to raise_error(ArgumentError)
+      end
+
+      it 'when given an prefixed_key without the expected prefix' do
+        expect { described_class.as_base_key("UNEXPECTED_PREFIX") }.to raise_error(ArgumentError)
+      end
+    end
+
+    it 'returns the given prefixed_key without the UmdIPManager::Group.PREFIX' do
+      expect(described_class.as_base_key('umd.ip.manager:foo')).to eq('foo')
+    end
+  end
+end


### PR DESCRIPTION
UmdIPManager service class can be used to get the list of all groups, the list of groups that contain a particular IP address, or whether a particular IP address is contained by a particular group.

https://issues.umd.edu/browse/LIBAVALON-263