### PR TITLE
LIBAVALON-264. Add form to select and add an IP Manager group to an item's special access

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -55,12 +55,15 @@ class Admin::CollectionsController < ApplicationController
         @users = @collection.default_read_users
         @virtual_groups = @collection.default_virtual_read_groups
         @ip_groups = @collection.default_ip_read_groups
-        @umd_ip_manager_groups = @collection.default_umd_ip_manager_read_groups
         @visibility = @collection.default_visibility
 
         @addable_groups = Admin::Group.non_system_groups.reject { |g| @groups.include? g.name }
         @addable_courses = Course.all.reject { |c| @virtual_groups.include? c.context_id }
-        @addable_umd_ip_manager_groups = UmdIPManager.new.groups.reject { |g| @umd_ip_manager_groups.include? g.prefixed_key }
+
+        umd_ip_manager_read_groups = @collection.default_umd_ip_manager_read_groups
+        all_umd_ip_manager_groups = UmdIPManager.new.groups
+        @umd_ip_manager_groups = all_umd_ip_manager_groups.select { |g| umd_ip_manager_read_groups.include? g.prefixed_key }
+        @addable_umd_ip_manager_groups = all_umd_ip_manager_groups.reject { |g| umd_ip_manager_read_groups.include? g.prefixed_key }
       }
     end
   end

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -60,8 +60,10 @@ class Admin::CollectionsController < ApplicationController
         @addable_groups = Admin::Group.non_system_groups.reject { |g| @groups.include? g.name }
         @addable_courses = Course.all.reject { |c| @virtual_groups.include? c.context_id }
 
-        umd_ip_manager_read_groups = @collection.default_umd_ip_manager_read_groups
         all_umd_ip_manager_groups = UmdIPManager.new.groups
+        @umd_ip_manager_error = t('errors.umd_ip_manager_error') unless all_umd_ip_manager_groups.success?
+
+        umd_ip_manager_read_groups = @collection.default_umd_ip_manager_read_groups
         @umd_ip_manager_groups = all_umd_ip_manager_groups.select { |g| umd_ip_manager_read_groups.include? g.prefixed_key }
         @addable_umd_ip_manager_groups = all_umd_ip_manager_groups.reject { |g| umd_ip_manager_read_groups.include? g.prefixed_key }
       }

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -55,10 +55,12 @@ class Admin::CollectionsController < ApplicationController
         @users = @collection.default_read_users
         @virtual_groups = @collection.default_virtual_read_groups
         @ip_groups = @collection.default_ip_read_groups
+        @umd_ip_manager_groups = @collection.default_umd_ip_manager_read_groups
         @visibility = @collection.default_visibility
 
         @addable_groups = Admin::Group.non_system_groups.reject { |g| @groups.include? g.name }
         @addable_courses = Course.all.reject { |c| @virtual_groups.include? c.context_id }
+        @addable_umd_ip_manager_groups = UmdIPManager.new.groups.reject { |g| @umd_ip_manager_groups.include? g.prefixed_key }
       }
     end
   end
@@ -261,7 +263,7 @@ class Admin::CollectionsController < ApplicationController
 
   def update_access(collection, params)
     # If Save Access Setting button or Add/Remove User/Group button has been clicked
-    ["group", "class", "user", "ipaddress"].each do |title|
+    ["group", "class", "user", "ipaddress", "umd_ip_manager_group"].each do |title|
       if params["submit_add_#{title}"].present?
         if params["add_#{title}"].present?
           val = params["add_#{title}"].strip
@@ -282,7 +284,7 @@ class Admin::CollectionsController < ApplicationController
       end
 
       if params["remove_#{title}"].present?
-        if ["group", "class", "ipaddress"].include? title
+        if ["group", "class", "ipaddress", "umd_ip_manager_group"].include? title
           # This is a hack to deal with the fact that calling default_read_groups#delete isn't marking the record as dirty
           # TODO: Ensure default_read_groups is tracked by ActiveModel::Dirty
           collection.default_read_groups_will_change!

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -314,7 +314,11 @@ class MediaObjectsController < ApplicationController
       all_umd_ip_manager_groups = UmdIPManager.new.groups
       @umd_ip_manager_error = t('errors.umd_ip_manager_error') unless all_umd_ip_manager_groups.success?
 
+      # The following hash is needed to map the Group prefixed_key in leases to the human-readable name for display
+      @umd_ip_manager_keys_to_names = Hash[all_umd_ip_manager_groups.map { |g| [g.prefixed_key, g.name] }]
+
       umd_ip_manager_read_groups = @media_object.umd_ip_manager_read_groups
+      @umd_ip_manager_leases = @media_object.leases('umd_ip_manager')
       @umd_ip_manager_groups = all_umd_ip_manager_groups.select { |g| umd_ip_manager_read_groups.include? g.prefixed_key }
       @addable_umd_ip_manager_groups = all_umd_ip_manager_groups.reject { |g| umd_ip_manager_read_groups.include? g.prefixed_key }
     end

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -304,15 +304,17 @@ class MediaObjectsController < ApplicationController
       @virtual_leases = @media_object.leases('external')
       @ip_groups = @media_object.ip_read_groups
       @ip_leases = @media_object.leases('ip')
-      @umd_ip_manager_groups = @media_object.umd_ip_manager_read_groups
-      @umd_ip_manager_leases = @media_object.leases('umd_ip_manager')
       @visibility = @media_object.visibility
 
       @active_access_tokens = AccessToken.active.where(media_object_id: @media_object.id).order(:expiration)
 
       @addable_groups = Admin::Group.non_system_groups.reject { |g| @groups.include? g.name }
       @addable_courses = Course.all.reject { |c| @virtual_groups.include? c.context_id }
-      @addable_umd_ip_manager_groups = UmdIPManager.new.groups.reject { |g| @umd_ip_manager_groups.include? g.prefixed_key }
+
+      umd_ip_manager_read_groups = @media_object.umd_ip_manager_read_groups
+      all_umd_ip_manager_groups = UmdIPManager.new.groups
+      @umd_ip_manager_groups = all_umd_ip_manager_groups.select { |g| umd_ip_manager_read_groups.include? g.prefixed_key }
+      @addable_umd_ip_manager_groups = all_umd_ip_manager_groups.reject { |g| umd_ip_manager_read_groups.include? g.prefixed_key }
     end
   end
 

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -311,8 +311,10 @@ class MediaObjectsController < ApplicationController
       @addable_groups = Admin::Group.non_system_groups.reject { |g| @groups.include? g.name }
       @addable_courses = Course.all.reject { |c| @virtual_groups.include? c.context_id }
 
-      umd_ip_manager_read_groups = @media_object.umd_ip_manager_read_groups
       all_umd_ip_manager_groups = UmdIPManager.new.groups
+      @umd_ip_manager_error = t('errors.umd_ip_manager_error') unless all_umd_ip_manager_groups.success?
+
+      umd_ip_manager_read_groups = @media_object.umd_ip_manager_read_groups
       @umd_ip_manager_groups = all_umd_ip_manager_groups.select { |g| umd_ip_manager_read_groups.include? g.prefixed_key }
       @addable_umd_ip_manager_groups = all_umd_ip_manager_groups.reject { |g| umd_ip_manager_read_groups.include? g.prefixed_key }
     end

--- a/app/controllers/media_objects_controller.rb
+++ b/app/controllers/media_objects_controller.rb
@@ -304,12 +304,15 @@ class MediaObjectsController < ApplicationController
       @virtual_leases = @media_object.leases('external')
       @ip_groups = @media_object.ip_read_groups
       @ip_leases = @media_object.leases('ip')
+      @umd_ip_manager_groups = @media_object.umd_ip_manager_read_groups
+      @umd_ip_manager_leases = @media_object.leases('umd_ip_manager')
       @visibility = @media_object.visibility
 
       @active_access_tokens = AccessToken.active.where(media_object_id: @media_object.id).order(:expiration)
 
       @addable_groups = Admin::Group.non_system_groups.reject { |g| @groups.include? g.name }
       @addable_courses = Course.all.reject { |c| @virtual_groups.include? c.context_id }
+      @addable_umd_ip_manager_groups = UmdIPManager.new.groups.reject { |g| @umd_ip_manager_groups.include? g.prefixed_key }
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -222,13 +222,31 @@ module ApplicationHelper
   end
 
   def umd_ip_manager_group_display(value)
-    # Value is assumed to be a UmdIPManager::Group
-    value.name
+    if value.is_a?(UmdIPManager::Group)
+      # For groups without leases, just return the human-readable name for the
+      # groups
+      return value.name
+    elsif !@umd_ip_manager_keys_to_names.nil?
+      # For leases, use @umd_ip_manager_keys_to_names to retrieve the
+      # human-readable name for the prefixed_key provided by the lease,
+      # or the value itself if it is not found.
+      return @umd_ip_manager_keys_to_names.fetch(value, value)
+    end
+    # This shouldn't happen, but if not a UmdIPManager::Group, and
+    # @umd_ip_manager_keys_to_names is not provided, simply return the given
+    # value
+    value
   end
 
   def umd_ip_manager_group_access_object_remove_helper(value)
-    # Value is assumed to be a UmdIPManager::Group
-    value.prefixed_key
+    if value.is_a?(UmdIPManager::Group)
+      # For groups without leases, return the prefixed_key, so it will be
+      # used as the id for the "remove"
+      value.prefixed_key
+    else
+      # For leases just return whatever we are given
+      value
+    end
   end
 
   def truncate_center label, output_label_length, end_length = 0

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -221,6 +221,16 @@ module ApplicationHelper
     c.nil? ? value : (c.title || c.label || value)
   end
 
+  def umd_ip_manager_group_display(value)
+    # Value is assumed to be a UmdIPManager::Group
+    value.name
+  end
+
+  def umd_ip_manager_group_access_object_remove_helper(value)
+    # Value is assumed to be a UmdIPManager::Group
+    value.prefixed_key
+  end
+
   def truncate_center label, output_label_length, end_length = 0
     end_length = output_label_length / 2 - 3 if end_length == 0
     truncate(label, length: output_label_length,

--- a/app/jobs/bulk_action_jobs.rb
+++ b/app/jobs/bulk_action_jobs.rb
@@ -23,7 +23,7 @@ module BulkActionJobs
         media_object.hidden = params[:hidden] if !params[:hidden].nil?
         media_object.visibility = params[:visibility] unless params[:visibility].blank?
         # Limited access stuff
-        ["group", "class", "user", "ipaddress"].each do |title|
+        ["group", "class", "user", "ipaddress", "umd_ip_manager_group"].each do |title|
           if params["submit_add_#{title}"].present?
             begin_time = params["add_#{title}_begin"].blank? ? nil : params["add_#{title}_begin"]
             end_time = params["add_#{title}_end"].blank? ? nil : params["add_#{title}_end"]
@@ -70,7 +70,7 @@ module BulkActionJobs
           end
           if params["submit_remove_#{title}"].present?
             if params[title].present?
-              if ["group", "class", "ipaddress"].include? title
+              if ["group", "class", "ipaddress", "umd_ip_manager_group"].include? title
                 media_object.read_groups -= [params[title]]
                 media_object.governing_policies.each do |policy|
                   if policy.class==Lease && policy.inherited_read_groups.include?(params[title])

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -37,7 +37,12 @@ class Ability
     @user_groups |= current_user.groups if current_user and current_user.respond_to? :groups
     @user_groups |= ['registered'] unless current_user.new_record?
     @user_groups |= @options[:virtual_groups] if @options.present? and @options.has_key? :virtual_groups
-    @user_groups |= [@options[:remote_ip]] if @options.present? and @options.has_key? :remote_ip
+    if @options.present? and @options.has_key? :remote_ip
+      remote_ip = @options[:remote_ip]
+      @user_groups |= [remote_ip]
+      umd_ip_manager_groups = UmdIPManager.new.api.groups_for_ip(remote_ip)
+      @user_groups |= umd_ip_manager_groups.map { |g| g.prefixed_key }
+    end
 
     if @options.present? && @options.has_key?(:access_token)
       token = @options[:access_token]

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -40,7 +40,7 @@ class Ability
     if @options.present? and @options.has_key? :remote_ip
       remote_ip = @options[:remote_ip]
       @user_groups |= [remote_ip]
-      umd_ip_manager_groups = UmdIPManager.new.api.groups_for_ip(remote_ip)
+      umd_ip_manager_groups = UmdIPManager.new.groups(ip_address: remote_ip)
       @user_groups |= umd_ip_manager_groups.map { |g| g.prefixed_key }
     end
 

--- a/app/models/access_control_step.rb
+++ b/app/models/access_control_step.rb
@@ -32,7 +32,7 @@ class AccessControlStep < Avalon::Workflow::BasicStep
 
     # Limited access stuff
     limited_access_submit = false
-    ["group", "class", "user", "ipaddress"].each do |title|
+    ["group", "class", "user", "ipaddress", "umd_ip_manager_group"].each do |title|
       if context["submit_add_#{title}"].present?
         limited_access_submit = true
         begin_time = context["add_#{title}_begin"].blank? ? nil : context["add_#{title}_begin"]
@@ -81,7 +81,7 @@ class AccessControlStep < Avalon::Workflow::BasicStep
       end
       if context["remove_#{title}"].present?
         limited_access_submit = true
-        if ["group", "class", "ipaddress"].include? title
+        if ["group", "class", "ipaddress", "umd_ip_manager_group"].include? title
           media_object.read_groups -= [context["remove_#{title}"]]
         else
           media_object.read_users -= [context["remove_#{title}"]]
@@ -107,6 +107,10 @@ class AccessControlStep < Avalon::Workflow::BasicStep
     context[:virtual_groups] = media_object.virtual_read_groups
     context[:ip_groups] = media_object.ip_read_groups
     context[:group_leases] = media_object.leases('local')
+    # --- TODO --- Make a real implmentation
+    context[:umd_ip_manager_groups] = media_object.umd_ip_manager_read_groups
+    context[:addable_umd_ip_manager_groups] = UmdIPManager.new.groups.reject { |g| context[:umd_ip_manager_groups].include? g.prefixed_key }
+    # -- end TODO
     context[:user_leases] = media_object.leases('user')
     context[:virtual_leases] = media_object.leases('external')
     context[:ip_leases] = media_object.leases('ip')

--- a/app/models/access_control_step.rb
+++ b/app/models/access_control_step.rb
@@ -106,16 +106,14 @@ class AccessControlStep < Avalon::Workflow::BasicStep
     context[:groups] = media_object.read_groups
     context[:virtual_groups] = media_object.virtual_read_groups
     context[:ip_groups] = media_object.ip_read_groups
-    context[:group_leases] = media_object.leases('local')
-    # --- TODO --- Make a real implmentation
     context[:umd_ip_manager_groups] = media_object.umd_ip_manager_read_groups
-    context[:addable_umd_ip_manager_groups] = UmdIPManager.new.groups.reject { |g| context[:umd_ip_manager_groups].include? g.prefixed_key }
-    # -- end TODO
+    context[:group_leases] = media_object.leases('local')
     context[:user_leases] = media_object.leases('user')
     context[:virtual_leases] = media_object.leases('external')
     context[:ip_leases] = media_object.leases('ip')
     context[:addable_groups] = Admin::Group.non_system_groups.reject { |g| context[:groups].include? g.name }
     context[:addable_courses] = Course.all.reject { |c| context[:virtual_groups].include? c.context_id }
+    context[:addable_umd_ip_manager_groups] = UmdIPManager.new.groups.reject { |g| context[:umd_ip_manager_groups].include? g.prefixed_key }
     context
   end
 end

--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -232,8 +232,12 @@ class Admin::Collection < ActiveFedora::Base
     self.default_read_groups.select {|g| IPAddr.new(g) rescue false }
   end
 
+  def default_umd_ip_manager_read_groups
+    self.default_read_groups.select {|g| UmdIPManager::Group.valid_prefixed_key?(g) }
+  end
+
   def default_virtual_read_groups
-    self.default_read_groups.to_a - represented_default_visibility - default_local_read_groups - default_ip_read_groups
+    self.default_read_groups.to_a - represented_default_visibility - default_local_read_groups - default_ip_read_groups - default_umd_ip_manager_read_groups
   end
 
   def default_visibility=(value)

--- a/app/models/concerns/virtual_groups.rb
+++ b/app/models/concerns/virtual_groups.rb
@@ -25,8 +25,12 @@
         self.read_groups.select {|g| IPAddr.new(g) rescue false }
       end
 
+      def umd_ip_manager_read_groups
+        self.read_groups.select {|g| UmdIPManager::Group.valid_prefixed_key?(g) }
+      end
+
       def virtual_read_groups
-        self.read_groups - represented_visibility - local_read_groups - ip_read_groups
+        self.read_groups - represented_visibility - local_read_groups - ip_read_groups - umd_ip_manager_read_groups
       end
     end
 #   end

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -355,6 +355,7 @@ class MediaObject < ActiveFedora::Base
     else
       actors << "collection staff" if visibility == "private"
       actors << "specific users" if read_users.any? || leases('user').any?
+      # -- TODO - need anything here for UMD IP Manager Groups?
 
       if visibility == "restricted"
         actors << "logged-in users"

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -355,7 +355,6 @@ class MediaObject < ActiveFedora::Base
     else
       actors << "collection staff" if visibility == "private"
       actors << "specific users" if read_users.any? || leases('user').any?
-      # -- TODO - need anything here for UMD IP Manager Groups?
 
       if visibility == "restricted"
         actors << "logged-in users"
@@ -363,7 +362,8 @@ class MediaObject < ActiveFedora::Base
         actors << "users in specific groups"
       end
 
-      actors << "users in specific IP Ranges" if ip_read_groups.any? || leases('ip').any?
+      actors << "users in specific IP Ranges" if ip_read_groups.any? || leases('ip').any? ||
+                                                 umd_ip_manager_read_groups.any? || leases('umd_ip_manager').any?
     end
 
     "This item is accessible by: #{actors.join(', ')}."

--- a/app/services/umd_ip_manager.rb
+++ b/app/services/umd_ip_manager.rb
@@ -11,6 +11,7 @@ class UmdIPManager
     groups = ip_address.nil? ? api.all_groups : api.groups_for_ip(ip_address)
     GroupsResult.new(groups: groups)
   rescue StandardError => e
+    Rails.logger.error(e)
     GroupsResult.new(errors: [e.message])
   end
 
@@ -22,6 +23,7 @@ class UmdIPManager
       ip_is_member = api.ip_in_group?(group_key: group_key, ip_address: ip_address)
       CheckIPResult.new(ip_is_member: ip_is_member)
     rescue StandardError => e
+      Rails.logger.error(e)
       CheckIPResult.new(errors: [e.message])
     end
   end

--- a/app/views/modules/_access_control.html.erb
+++ b/app/views/modules/_access_control.html.erb
@@ -175,6 +175,8 @@ Unless required by applicable law or agreed to in writing, software distributed
     <%= render "modules/access_object", object: object,
           access_object: "umd_ip_manager_group", members: @umd_ip_manager_groups, leases: @umd_ip_manager_leases,
           dropdown_values: [@addable_umd_ip_manager_groups, 'prefixed_key', 'name'],
+          display_helper: :umd_ip_manager_group_display,
+          access_object_remove_helper: :umd_ip_manager_group_access_object_remove_helper,
           input_disabled: !can_update %>
   </div>
 </div>

--- a/app/views/modules/_access_control.html.erb
+++ b/app/views/modules/_access_control.html.erb
@@ -172,5 +172,9 @@ Unless required by applicable law or agreed to in writing, software distributed
     <%= render "modules/access_object", object: object,
           access_object: "ipaddress", members: @ip_groups, leases: @ip_leases,
           input_disabled: !can_update %>
+    <%= render "modules/access_object", object: object,
+          access_object: "umd_ip_manager_group", members: @umd_ip_manager_groups, leases: @umd_ip_manager_leases,
+          dropdown_values: [@addable_umd_ip_manager_groups, 'prefixed_key', 'name'],
+          input_disabled: !can_update %>
   </div>
 </div>

--- a/app/views/modules/_access_control.html.erb
+++ b/app/views/modules/_access_control.html.erb
@@ -172,11 +172,20 @@ Unless required by applicable law or agreed to in writing, software distributed
     <%= render "modules/access_object", object: object,
           access_object: "ipaddress", members: @ip_groups, leases: @ip_leases,
           input_disabled: !can_update %>
-    <%= render "modules/access_object", object: object,
-          access_object: "umd_ip_manager_group", members: @umd_ip_manager_groups, leases: @umd_ip_manager_leases,
-          dropdown_values: [@addable_umd_ip_manager_groups, 'prefixed_key', 'name'],
-          display_helper: :umd_ip_manager_group_display,
-          access_object_remove_helper: :umd_ip_manager_group_access_object_remove_helper,
-          input_disabled: !can_update %>
+    <% if @umd_ip_manager_error.nil? %>
+      <%= render "modules/access_object", object: object,
+            access_object: "umd_ip_manager_group", members: @umd_ip_manager_groups, leases: @umd_ip_manager_leases,
+            dropdown_values: [@addable_umd_ip_manager_groups, 'prefixed_key', 'name'],
+            display_helper: :umd_ip_manager_group_display,
+            access_object_remove_helper: :umd_ip_manager_group_access_object_remove_helper,
+            input_disabled: !can_update %>
+    <% else %>
+      <% access_object = "umd_ip_manager_group" %>
+      <div class="access-block col-lg-10" id="<%= access_object %>_management">
+       <%= bootstrap_form_for object do |form| %>
+         <%= render partial: "modules/tooltip", locals: { form: form, field: access_object, tooltip: t("access_control.#{access_object}"), options: {display_label: (t("access_control.#{access_object}label")+'*').html_safe} } %><br />
+         <div class="alert alert-danger"><%= @umd_ip_manager_error %></div>
+        <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/modules/_access_object.html.erb
+++ b/app/views/modules/_access_object.html.erb
@@ -82,8 +82,14 @@ Unless required by applicable law or agreed to in writing, software distributed
           <td class='access_list_dates'></td>
           <% if !input_disabled %>
           <td class='access_list_remove'>
+            <% if defined?(access_object_remove_helper) && access_object_remove_helper.present? %>
+            <% remove_object = self.send(access_object_remove_helper, member_object) %>
+            <% else %>
+            <% remove_object = member_object %>
+            <% end %>
+
             <%= link_to "×",
-                polymorphic_path(object, "remove_#{access_object}".to_sym => member_object, step: @active_step, donot_advance: true),
+                polymorphic_path(object, "remove_#{access_object}".to_sym => remove_object, step: @active_step, donot_advance: true),
                 method: "put",
                 class: "btn btn-xs close remove" %>
           </td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,7 @@ en:
       blank: "field is required."
       taken: "is taken."
       dateformat: "(%{date}) is in wrong format."
+    umd_ip_manager_error: Unable to access IP Manager server
   access_token:
     info_for_patron_snippet_html: |
       The following URL allows %{access_mode} of "%{media_object_title}" until %{expiration}:<br>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -150,6 +150,7 @@ en:
     grouplabel: "Avalon Group"
     classlabel: "External Group"
     ipaddresslabel: "IP Address or Range"
+    umd_ip_manager_grouplabel: "UMD IP Manager"
     depositor: |
       Depositors add media to the collection and describe it with metadata.
       They can publish items but not unpublish. They can only modify or
@@ -178,6 +179,8 @@ en:
       or ffaa:aaff:bbcc:ddee:1122:3344:5566:7777
       or ffaa:aaff:bbcc:ddee:1122:3344:5566:7777/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ff00
       Start and end dates are not required; if included, access for the specified IP Address(es) will start at the beginning of the start date and end at the beginning of the end date. Otherwise, access will be open ended for the specified IP Address(es).
+    umd_ip_manager_group: |
+      Select an UMD IP Manager group from the dropdown list below to grant it access to an item or collection.  Start and end dates are not required; if included, access for the specified group will start at the beginning of the start date and end at the beginning of the end date. Otherwise, access will be open ended for the specified group.
 
   contact:
     title: 'Contact Us - %{application_name}'

--- a/spec/controllers/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin_collections_controller_spec.rb
@@ -386,13 +386,17 @@ describe Admin::CollectionsController, type: :controller do
       it "IP address/range" do
         expect{ put 'update', params: { id: collection.id, submit_add_ipaddress: "Add", add_ipaddress: "255.0.0.1" }}.to change{ collection.reload.default_read_groups.size }.by(1)
       end
+
+      it "UMD IP Manager Group" do
+        expect{ put 'update', params: { id: collection.id, submit_add_umd_ip_manager_group: "Add", add_umd_ip_manager_group: "#{UmdIPManager::GROUP_PREFIX}TestGroup" }}.to change{ collection.reload.default_read_groups.size }.by(1)
+      end
     end
 
 
     context "remove existing special access" do
       before do
         collection.default_read_users = ["test1@example.com"]
-        collection.default_read_groups = ["test_group", "external_group", "255.0.1.1"]
+        collection.default_read_groups = ["test_group", "external_group", "255.0.1.1", "#{UmdIPManager::GROUP_PREFIX}TestGroup"]
         collection.save!
       end
       it "user" do
@@ -409,6 +413,10 @@ describe Admin::CollectionsController, type: :controller do
 
       it "IP address/range" do
         expect{ put 'update', params: { id: collection.id, remove_ipaddress: "255.0.1.1" }}.to change{ collection.reload.default_read_groups.size }.by(-1)
+      end
+
+      it "UMD IP Manager Group" do
+        expect{ put 'update', params: { id: collection.id, remove_umd_ip_manager_group: "#{UmdIPManager::GROUP_PREFIX}TestGroup" }}.to change{ collection.reload.default_read_groups.size }.by(-1)
       end
     end
 

--- a/spec/controllers/admin_collections_controller_spec.rb
+++ b/spec/controllers/admin_collections_controller_spec.rb
@@ -248,6 +248,64 @@ describe Admin::CollectionsController, type: :controller do
         expect(JSON.parse(response.body)["errors"].first.class).to eq String
       end
     end
+
+    context "Assign Special Access - UMD IP Manager Groups" do
+      it "should provide an error message if UMD IP Manager group retrieval fails" do
+        login_user collection.managers.first
+
+        allow_any_instance_of(UmdIPManager).to receive(:groups).and_return(UmdIPManager::GroupsResult.new(errors: ['An error occurred!']))
+        get 'show', params: { id: collection.id }
+
+        expect(controller.instance_variable_get('@umd_ip_manager_error')).to_not be(nil)
+        expect(controller.instance_variable_get('@umd_ip_manager_groups')).to be_empty
+        expect(controller.instance_variable_get('@addable_umd_ip_manager_groups')).to be_empty
+      end
+
+      context "when UMD IP Manager group retrieval succeeds" do
+        let (:test_group1) { UmdIPManager::Group.new(key: 'test1', name: 'Test Group 1') }
+        let (:test_group2) { UmdIPManager::Group.new(key: 'test2', name: 'Test Group 2') }
+
+        before(:each) do
+          login_user collection.managers.first
+
+          allow_any_instance_of(UmdIPManager).to receive(:groups).and_return(
+            UmdIPManager::GroupsResult.new(groups: [ test_group1, test_group2 ])
+          )
+        end
+
+        it "should display groups" do
+          get 'show', params: { id: collection.id }
+
+          expect(controller.instance_variable_get('@umd_ip_manager_error')).to be(nil)
+          expect(controller.instance_variable_get('@umd_ip_manager_groups').count).to eq(0)
+          expect(controller.instance_variable_get('@addable_umd_ip_manager_groups')).to contain_exactly(test_group1, test_group2)
+        end
+
+        it "dropdown should not contain already selected groups" do
+          collection.default_read_groups = [test_group1.prefixed_key]
+          collection.save!
+
+          get 'show', params: { id: collection.id }
+
+          expect(controller.instance_variable_get('@umd_ip_manager_error')).to be(nil)
+          expect(controller.instance_variable_get('@umd_ip_manager_groups')).to contain_exactly(test_group1)
+          expect(controller.instance_variable_get('@addable_umd_ip_manager_groups')).to contain_exactly(test_group2)
+        end
+
+        it "a group in collection.default_read_groups that has been deleted from IP Manager should be ignored" do
+          deleted_group = UmdIPManager::Group.new(key: 'deleted_group', name: 'Deleted Group')
+
+          collection.default_read_groups = [test_group1.prefixed_key, deleted_group.prefixed_key]
+          collection.save!
+
+          get 'show', params: { id: collection.id }
+
+          expect(controller.instance_variable_get('@umd_ip_manager_error')).to be(nil)
+          expect(controller.instance_variable_get('@umd_ip_manager_groups')).to contain_exactly(test_group1)
+          expect(controller.instance_variable_get('@addable_umd_ip_manager_groups')).to contain_exactly(test_group2)
+        end
+      end
+    end
   end
 
   describe "#items" do

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -1235,6 +1235,7 @@ describe MediaObjectsController, type: :controller do
       let!(:group) { Faker::Lorem.word }
       let!(:classname) { Faker::Lorem.word }
       let!(:ipaddr) { Faker::Internet.ip_v4_address }
+      let!(:umd_ip_manager_group) { "#{UmdIPManager::GROUP_PREFIX}TestGroup" }
       before(:each) { login_user media_object.collection.managers.first }
 
       context "grant and revoke special read access" do
@@ -1253,6 +1254,10 @@ describe MediaObjectsController, type: :controller do
         it "grants and revokes special read access to ips" do
           expect { put :update, params: { id: media_object.id, step: 'access-control', donot_advance: 'true', add_ipaddress: ipaddr, submit_add_ipaddress: 'Add' } }.to change { media_object.reload.read_groups }.from([]).to([ipaddr])
           expect { put :update, params: { id: media_object.id, step: 'access-control', donot_advance: 'true', remove_ipaddress: ipaddr, submit_remove_ipaddress: 'Remove' } }.to change { media_object.reload.read_groups }.from([ipaddr]).to([])
+        end
+        it "grants and revokes special read access to UMD IP Manager groups" do
+          expect { put :update, params: { id: media_object.id, step: 'access-control', donot_advance: 'true', add_umd_ip_manager_group: umd_ip_manager_group, submit_add_umd_ip_manager_group: 'Add' } }.to change { media_object.reload.read_groups }.from([]).to([umd_ip_manager_group])
+          expect { put :update, params: { id: media_object.id, step: 'access-control', donot_advance: 'true', remove_umd_ip_manager_group: umd_ip_manager_group, submit_remove_umd_ip_manager_group: 'Remove' } }.to change { media_object.reload.read_groups }.from([umd_ip_manager_group]).to([])
         end
       end
 

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -702,6 +702,20 @@ describe MediaObjectsController, type: :controller do
           expect(controller.instance_variable_get('@umd_ip_manager_groups')).to contain_exactly(test_group1)
           expect(controller.instance_variable_get('@addable_umd_ip_manager_groups')).to contain_exactly(test_group2)
         end
+
+        it "should display leases" do
+          lease = FactoryBot.create(:lease)
+          lease.inherited_read_groups = [test_group1.prefixed_key]
+          lease.save!
+          media_object.governing_policies += [ lease ]
+          media_object.save!
+
+          get 'edit', params: { id: media_object.id, step: 'access-control' }
+
+          umd_ip_manager_leases = controller.instance_variable_get('@umd_ip_manager_leases')
+          expect(umd_ip_manager_leases.count).to eq(1)
+          expect(umd_ip_manager_leases.first.inherited_read_groups).to contain_exactly(test_group1.prefixed_key)
+        end
       end
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -227,4 +227,44 @@ describe ApplicationHelper do
       end
     end
   end
+
+  describe '#umd_ip_manager_group_display' do
+    before(:each) do
+      @umd_ip_manager_keys_to_names = { 'test1' => 'Test Name 1',  'test2' => 'Test Name 2' }
+    end
+
+    it 'given a UmdIPManager::Group, returns the human-readable "name" for the group' do
+      group = UmdIPManager::Group.new(key: 'group1', name: 'Group 1')
+      expect(helper.umd_ip_manager_group_display(group)).to eq('Group 1')
+    end
+
+    context 'given anything else' do
+      context 'and @umd_ip_manager_keys_to_names variable is non-nil' do
+        it 'return the human-readable name from @umd_ip_manager_keys_to_names, if found' do
+          value = 'test1'
+          expect(helper.umd_ip_manager_group_display(value)).to eq('Test Name 1')
+        end
+        it 'if not found in @umd_ip_manager_keys_to_names, simply return the value' do
+          value = 'some_other_value'
+          expect(helper.umd_ip_manager_group_display(value)).to eq('some_other_value')
+        end
+      end
+      it 'otherwise, simply return the given value' do
+        @umd_ip_manager_keys_to_names = nil
+        value = 'some_other_value2'
+        expect(helper.umd_ip_manager_group_display(value)).to eq('some_other_value2')
+      end
+    end
+  end
+
+  describe '#umd_ip_manager_group_access_object_remove_helper' do
+    it 'given a UmdIPManager::Group, returns the prefixed_key so the API endpoint can identify the group' do
+      group = UmdIPManager::Group.new(key: 'group1', name: 'Group 1')
+      expect(helper.umd_ip_manager_group_access_object_remove_helper(group)).to eq(group.prefixed_key)
+    end
+    it 'given any other object (such as a string), simply returns the object' do
+      value = 'some_other_value'
+      expect(helper.umd_ip_manager_group_access_object_remove_helper(value)).to eq(value)
+    end
+  end
 end

--- a/spec/models/concerns/virtual_groups_spec.rb
+++ b/spec/models/concerns/virtual_groups_spec.rb
@@ -30,8 +30,12 @@ describe VirtualGroups do
     let!(:local_groups) {[FactoryBot.create(:group).name, FactoryBot.create(:group).name]}
     let(:virtual_groups) {["vgroup1", "vgroup2"]}
     let(:ip_groups) {[Faker::Internet.ip_v4_address, Faker::Internet.ip_v6_address, Faker::Internet.ip_v4_address + "/24"]}
+    let(:umd_ip_manager_groups) {
+      ["#{UmdIPManager::GROUP_PREFIX}UmdIPTestGroup1", "#{UmdIPManager::GROUP_PREFIX}UmdIPTestGroup2"]
+    }
+
     before(:each) do
-      subject.read_groups = local_groups + virtual_groups + ip_groups
+      subject.read_groups = local_groups + virtual_groups + ip_groups + umd_ip_manager_groups
     end
 
     describe '#local_group_exceptions' do
@@ -49,6 +53,12 @@ describe VirtualGroups do
     describe '#ip_group_exceptions' do
       it 'should have only ip groups' do
         expect(subject.ip_read_groups).to eq(ip_groups)
+      end
+    end
+
+    describe '#umd_ip_group_exceptions' do
+      it 'should have only UMD IP Manager groups' do
+        expect(subject.umd_ip_manager_read_groups).to eq(umd_ip_manager_groups)
       end
     end
   end

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -258,6 +258,8 @@ describe MediaObject do
         expect(subject.can?(:read, media_object)).to be_truthy
       end
     end
+
+    # TODO -- Add test case for UMD IP Manager?
   end
 
   describe "Required metadata is present" do

--- a/spec/models/media_object_spec.rb
+++ b/spec/models/media_object_spec.rb
@@ -258,8 +258,6 @@ describe MediaObject do
         expect(subject.can?(:read, media_object)).to be_truthy
       end
     end
-
-    # TODO -- Add test case for UMD IP Manager?
   end
 
   describe "Required metadata is present" do
@@ -1006,6 +1004,23 @@ describe MediaObject do
 
       it 'returns compound text' do
         expect(media_object.access_text).to eq("This item is accessible by: collection staff, users in specific groups, users in specific IP Ranges.")
+      end
+    end
+
+    context "private item" do
+      let (:group) { UmdIPManager::Group.new(key: 'test_umd_ip_manager_group', name: 'Test UMD IP Manager Group') }
+      before do
+        media_object.visibility = "private"
+      end
+
+      it 'with UmdIPManager::Group, returns text indicating item is accessible for specific IP ranges' do
+        media_object.read_groups += [group.prefixed_key]
+        media_object.save!
+        expect(media_object.access_text).to eq("This item is accessible by: collection staff, users in specific IP Ranges.")
+      end
+      it 'with UmdIPManager::Group lease, returns text indicating item is accessible for specific IP ranges' do
+        media_object.governing_policies += [FactoryBot.create(:lease, inherited_read_groups: [group.prefixed_key])]
+        expect(media_object.access_text).to eq("This item is accessible by: collection staff, users in specific IP Ranges.")
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,6 +44,8 @@ require 'noid/rails/rspec'
 require "email_spec"
 require "email_spec/rspec"
 require 'webdrivers'
+require_relative 'services/mock_umd_ip_manager'
+
 # require 'equivalent-xml/rspec_matchers'
 # require 'fakefs/safe'
 # require 'fileutils'
@@ -134,6 +136,7 @@ RSpec.configure do |config|
     ActiveJob::Base.queue_adapter.enqueued_jobs = []
     ActiveJob::Base.queue_adapter.performed_jobs = []
     Settings.bib_retriever = { 'default' => { 'protocol' => 'sru', 'url' => 'http://zgate.example.edu:9000/db', 'retriever_class' => 'Avalon::BibRetriever::SRU', 'retriever_class_require' => 'avalon/bib_retriever/sru' } }
+    enable_umd_ip_manager_mock
   end
 
   config.after :each do

--- a/spec/services/mock_umd_ip_manager.rb
+++ b/spec/services/mock_umd_ip_manager.rb
@@ -1,0 +1,31 @@
+# Enables a mock of the UmdIPManager, preventing any network calls.
+# This method is typically called from "rails_helper.rb", so that
+# tests can run without having to individually mock out UmdIPManager calls
+def enable_umd_ip_manager_mock
+  allow_any_instance_of(UmdIPManager).to receive(:api).and_return(UmdIPManager::MockAPI.new)
+end
+
+# Disables UmdIPManager mock set by the "enable_umd_ip_manager_mock" method,
+# allowing the actual UmdIPManager network calls to be tested. The network
+# calls themselves will typically be mocked as part of the test setup.
+def disable_umd_ip_manager_mock
+  allow_any_instance_of(UmdIPManager).to receive(:api).and_call_original
+end
+
+# Mock implementation of the UmdManager::API class
+class UmdIPManager::MockAPI
+  def initialize
+  end
+
+  def all_groups
+    []
+  end
+
+  def ip_in_group?(group_key:, ip_address:)
+    false
+  end
+
+  def groups_for_ip(ip_address)
+    []
+  end
+end

--- a/spec/services/umd_ip_manager_spec.rb
+++ b/spec/services/umd_ip_manager_spec.rb
@@ -64,6 +64,10 @@ def stub_ip_check_request_error(ip_address:, group:)
 end
 
 describe UmdIPManager do
+  before(:each) do
+    disable_umd_ip_manager_mock
+  end
+
   let(:ip_manager) {
     ENV['IP_MANAGER_SERVER_URL'] = 'http://ipmanager-local:3001'
     described_class.new

--- a/spec/services/umd_ip_manager_spec.rb
+++ b/spec/services/umd_ip_manager_spec.rb
@@ -13,14 +13,6 @@ def mock_ip_check_response(ip_address:, group:, contained:)
   }
 end
 
-def mock_ip_check_error_response(group:)
-  {
-    status: 404,
-    title: 'Group not found',
-    detail: "There is no group with the key '#{group}'."
-  }
-end
-
 def mock_ip_check_list_response(ip_address:, groups: {})
   {
     '@id': "http://ipmanager-local:3001/check?ip=#{ip_address}",
@@ -31,17 +23,6 @@ def mock_ip_check_list_response(ip_address:, groups: {})
   }
 end
 
-def stub_ip_check_request(ip_address:, group:, contained:)
-  stub_request(:get, 'ipmanager-local:3001/check').
-    with(query: {ip: ip_address, group: group}).
-    to_return(
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.dump(
-        mock_ip_check_response(ip_address: ip_address, group: group, contained: contained)
-      )
-    )
-end
-
 def stub_ip_check_list_request(ip_address:, groups: {})
   stub_request(:get, 'ipmanager-local:3001/check').
     with(query: {ip: ip_address}).
@@ -50,16 +31,6 @@ def stub_ip_check_list_request(ip_address:, groups: {})
       body: JSON.dump(
         mock_ip_check_list_response(ip_address: ip_address, groups: groups)
       )
-    )
-end
-
-def stub_ip_check_request_error(ip_address:, group:)
-  stub_request(:get, 'ipmanager-local:3001/check').
-    with(query: {ip: ip_address, group: group}).
-    to_return(
-      status: 404,
-      headers: {'Content-Type': 'application/problem+json'},
-      body: JSON.dump(mock_ip_check_error_response(group: group))
     )
 end
 
@@ -106,88 +77,9 @@ describe UmdIPManager do
       result = ip_manager.groups(ip_address: '127.0.0.1')
       expect(result.success?).to be(true)
       expect(result.groups.length).to eq(2)
-      expect(result.groups.map {|g| g.key}).to eq(%w[test1 test4])
+      expected_prefixed_keys = [ UmdIPManager::Group.as_prefixed_key('test1'), UmdIPManager::Group.as_prefixed_key('test4') ]
+      expect(result.groups.map {|g| g.prefixed_key}).to match_array(expected_prefixed_keys)
     end
-  end
-
-  context '#check_ip' do
-    it 'raises an ArgumentError when given invalid parameters' do
-      expect { ip_manager.check_ip }.to raise_error(ArgumentError)
-      expect { ip_manager.check_ip(group_key: '') }.to raise_error(ArgumentError)
-      expect { ip_manager.check_ip(ip_address: '') }.to raise_error(ArgumentError)
-      expect { ip_manager.check_ip(group_key: '', ip_address: '') }.to raise_error(ArgumentError)
-    end
-
-    it 'returns a successful CheckIPResult indicating whether an IP is a member when no errors occur' do
-      allow(ip_manager.api).to receive(:ip_in_group?).with(group_key: 'test_localhost', ip_address: '127.0.0.1').and_return(true)
-      allow(ip_manager.api).to receive(:ip_in_group?).with(group_key: 'test_localhost', ip_address: '192.168.1.105').and_return(false)
-
-      check_ip_result = ip_manager.check_ip(group_key: 'test_localhost', ip_address: '127.0.0.1')
-      expect(check_ip_result.success?).to be(true)
-      expect(check_ip_result.ip_is_member?).to be(true)
-
-      check_ip_result = ip_manager.check_ip(group_key: 'test_localhost', ip_address: '192.168.1.105')
-      expect(check_ip_result.success?).to be(true)
-      expect(check_ip_result.ip_is_member?).to be(false)
-    end
-
-    it 'returns a CheckIPResult with errors on failure' do
-      allow(ip_manager.api).to receive(:ip_in_group?) { raise StandardError, "An error occurred" }
-
-      check_ip_result = ip_manager.check_ip(group_key: 'test_localhost', ip_address: '127.0.0.1')
-      expect(check_ip_result.success?).to be(false)
-      expect(check_ip_result.ip_is_member?).to be(false)
-      expect(check_ip_result.errors.length).to eq(1)
-    end
-    context "#ip_is_member?" do
-      it 'returns true when IP is contained in group' do
-        stub_ip_check_request(ip_address: '127.0.0.1', group: 'test', contained: true)
-        result = ip_manager.check_ip(group_key: 'test', ip_address: '127.0.0.1')
-        expect(result.success?).to be(true)
-        expect(result.ip_is_member?).to be(true)
-      end
-
-      it 'returns false when IP is not contained in group' do
-        stub_ip_check_request(ip_address: '127.0.0.1', group: 'test', contained: false)
-        result = ip_manager.check_ip(group_key: 'test', ip_address: '127.0.0.1')
-        expect(result.success?).to be(true)
-        expect(result.ip_is_member?).to be(false)
-      end
-
-      it 'returns a CheckIPResult with errors if the group is not found' do
-        stub_ip_check_request_error(ip_address: '127.0.0.1', group: 'bad_group')
-        result = ip_manager.check_ip(group_key: 'bad_group', ip_address: '127.0.0.1')
-        expect(result.success?).to be(false)
-        expect(result.errors.length).to eq(1)
-        expect(result.errors[0]).to eq("There is no group with the key 'bad_group'.")
-      end
-    end
-  end
-end
-
-describe UmdIPManager::CheckIPResult do
-  context '#success?' do
-    it 'returns true when there are no errors' do
-      check_ip_result = described_class.new
-      expect(check_ip_result.success?).to be(true)
-      expect(check_ip_result.errors.length).to eq(0)
-    end
-
-    it 'returns false when there are errors' do
-      check_ip_result = described_class.new(errors: ['An error occurred!'])
-      expect(check_ip_result.success?).to be(false)
-      expect(check_ip_result.errors.length).to eq(1)
-    end
-  end
-
-  it 'returns true when an IP Address is a member of the group' do
-    check_ip_result = described_class.new(ip_is_member: true)
-    expect(check_ip_result.ip_is_member?).to be(true)
-  end
-
-  it 'returns false when an IP Address is not a member of the group' do
-    check_ip_result = described_class.new(ip_is_member: false)
-    expect(check_ip_result.ip_is_member?).to be(false)
   end
 end
 
@@ -225,11 +117,6 @@ end
 describe UmdIPManager::Group do
   EXPECTED_PREFIX = 'umd.ip.manager:'
 
-  it 'provides the key for a group' do
-    group = described_class.new(key: 'test-key', name: 'Test')
-    expect(group.key).to eq('test-key')
-  end
-
   it 'provides the prefixed_key for a group' do
     group = described_class.new(key: 'test-key', name: 'Test')
     expect(group.prefixed_key).to eq("#{EXPECTED_PREFIX}test-key")
@@ -252,7 +139,6 @@ describe UmdIPManager::Group do
 
     it 'is properly constructed when given valid parameters' do
       group = described_class.new(key: 'test-key', name: 'Test')
-      expect(group.key).to eq('test-key')
       expect(group.name).to eq('Test')
       expect(group.prefixed_key).to eq("#{EXPECTED_PREFIX}test-key")
     end
@@ -278,32 +164,8 @@ describe UmdIPManager::Group do
     end
   end
 
-  context '.as_key' do
-    context 'raises an ArgumentError' do
-      it 'when given a nil prefixed_key' do
-        expect { described_class.as_key(nil) }.to raise_error(ArgumentError)
-      end
-
-      it 'when given an empty prefixed_key' do
-        expect { described_class.as_key('') }.to raise_error(ArgumentError)
-      end
-
-      it 'when given a prefixed_key of only whitespace' do
-        expect { described_class.as_key("  \t  ") }.to raise_error(ArgumentError)
-      end
-
-      it 'when given a prefixed_key without the expected prefix' do
-        expect { described_class.as_key("UNEXPECTED_PREFIX") }.to raise_error(ArgumentError)
-      end
-    end
-
-    it 'returns the given prefixed_key without the UmdIPManager::Group.PREFIX' do
-      expect(described_class.as_key("#{EXPECTED_PREFIX}foo")).to eq('foo')
-    end
-  end
-
   context '.valid_prefixed_key?' do
-    context 'return false' do
+    context 'returns false' do
       it 'when given a nil prefixed_key' do
         expect(described_class.valid_prefixed_key?(nil)).to be(false)
       end

--- a/spec/services/umd_ip_manager_spec.rb
+++ b/spec/services/umd_ip_manager_spec.rb
@@ -71,7 +71,7 @@ describe UmdIPManager do
 
   context '#groups' do
     it 'returns a GroupsResult with a list of UmdIPManager::Groups on success' do
-      test_group = UmdIPManager::Group.new(base_key: 'test-group', name: 'Test Group')
+      test_group = UmdIPManager::Group.new(key: 'test-group', name: 'Test Group')
       allow(ip_manager.api).to receive(:all_groups) {
         [test_group]
       }
@@ -102,27 +102,27 @@ describe UmdIPManager do
       result = ip_manager.groups(ip_address: '127.0.0.1')
       expect(result.success?).to be(true)
       expect(result.groups.length).to eq(2)
-      expect(result.groups.map {|g| g.base_key}).to eq(%w[test1 test4])
+      expect(result.groups.map {|g| g.key}).to eq(%w[test1 test4])
     end
   end
 
   context '#check_ip' do
     it 'raises an ArgumentError when given invalid parameters' do
       expect { ip_manager.check_ip }.to raise_error(ArgumentError)
-      expect { ip_manager.check_ip(group_base_key: '') }.to raise_error(ArgumentError)
+      expect { ip_manager.check_ip(group_key: '') }.to raise_error(ArgumentError)
       expect { ip_manager.check_ip(ip_address: '') }.to raise_error(ArgumentError)
-      expect { ip_manager.check_ip(group_base_key: '', ip_address: '') }.to raise_error(ArgumentError)
+      expect { ip_manager.check_ip(group_key: '', ip_address: '') }.to raise_error(ArgumentError)
     end
 
     it 'returns a successful CheckIPResult indicating whether an IP is a member when no errors occur' do
-      allow(ip_manager.api).to receive(:ip_in_group?).with(group_base_key: 'test_localhost', ip_address: '127.0.0.1').and_return(true)
-      allow(ip_manager.api).to receive(:ip_in_group?).with(group_base_key: 'test_localhost', ip_address: '192.168.1.105').and_return(false)
+      allow(ip_manager.api).to receive(:ip_in_group?).with(group_key: 'test_localhost', ip_address: '127.0.0.1').and_return(true)
+      allow(ip_manager.api).to receive(:ip_in_group?).with(group_key: 'test_localhost', ip_address: '192.168.1.105').and_return(false)
 
-      check_ip_result = ip_manager.check_ip(group_base_key: 'test_localhost', ip_address: '127.0.0.1')
+      check_ip_result = ip_manager.check_ip(group_key: 'test_localhost', ip_address: '127.0.0.1')
       expect(check_ip_result.success?).to be(true)
       expect(check_ip_result.ip_is_member?).to be(true)
 
-      check_ip_result = ip_manager.check_ip(group_base_key: 'test_localhost', ip_address: '192.168.1.105')
+      check_ip_result = ip_manager.check_ip(group_key: 'test_localhost', ip_address: '192.168.1.105')
       expect(check_ip_result.success?).to be(true)
       expect(check_ip_result.ip_is_member?).to be(false)
     end
@@ -130,7 +130,7 @@ describe UmdIPManager do
     it 'returns a CheckIPResult with errors on failure' do
       allow(ip_manager.api).to receive(:ip_in_group?) { raise StandardError, "An error occurred" }
 
-      check_ip_result = ip_manager.check_ip(group_base_key: 'test_localhost', ip_address: '127.0.0.1')
+      check_ip_result = ip_manager.check_ip(group_key: 'test_localhost', ip_address: '127.0.0.1')
       expect(check_ip_result.success?).to be(false)
       expect(check_ip_result.ip_is_member?).to be(false)
       expect(check_ip_result.errors.length).to eq(1)
@@ -138,21 +138,21 @@ describe UmdIPManager do
     context "#ip_is_member?" do
       it 'returns true when IP is contained in group' do
         stub_ip_check_request(ip_address: '127.0.0.1', group: 'test', contained: true)
-        result = ip_manager.check_ip(group_base_key: 'test', ip_address: '127.0.0.1')
+        result = ip_manager.check_ip(group_key: 'test', ip_address: '127.0.0.1')
         expect(result.success?).to be(true)
         expect(result.ip_is_member?).to be(true)
       end
 
       it 'returns false when IP is not contained in group' do
         stub_ip_check_request(ip_address: '127.0.0.1', group: 'test', contained: false)
-        result = ip_manager.check_ip(group_base_key: 'test', ip_address: '127.0.0.1')
+        result = ip_manager.check_ip(group_key: 'test', ip_address: '127.0.0.1')
         expect(result.success?).to be(true)
         expect(result.ip_is_member?).to be(false)
       end
 
       it 'returns a CheckIPResult with errors if the group is not found' do
         stub_ip_check_request_error(ip_address: '127.0.0.1', group: 'bad_group')
-        result = ip_manager.check_ip(group_base_key: 'bad_group', ip_address: '127.0.0.1')
+        result = ip_manager.check_ip(group_key: 'bad_group', ip_address: '127.0.0.1')
         expect(result.success?).to be(false)
         expect(result.errors.length).to eq(1)
         expect(result.errors[0]).to eq("There is no group with the key 'bad_group'.")
@@ -203,8 +203,8 @@ describe UmdIPManager::GroupsResult do
   end
 
   it 'returns a list of provided groups' do
-    group1 = UmdIPManager::Group.new(base_key: 'group-1', name: 'Group 1')
-    group2 = UmdIPManager::Group.new(base_key: 'group-2', name: 'Group 2')
+    group1 = UmdIPManager::Group.new(key: 'group-1', name: 'Group 1')
+    group2 = UmdIPManager::Group.new(key: 'group-2', name: 'Group 2')
     groups = [group1, group2]
 
     groups_result = described_class.new(groups: groups)
@@ -221,18 +221,18 @@ end
 describe UmdIPManager::Group do
   EXPECTED_PREFIX = 'umd.ip.manager:'
 
-  it 'provides the base_key for a group' do
-    group = described_class.new(base_key: 'test-base-key', name: 'Test')
-    expect(group.base_key).to eq('test-base-key')
+  it 'provides the key for a group' do
+    group = described_class.new(key: 'test-key', name: 'Test')
+    expect(group.key).to eq('test-key')
   end
 
   it 'provides the prefixed_key for a group' do
-    group = described_class.new(base_key: 'test-base-key', name: 'Test')
-    expect(group.prefixed_key).to eq("#{EXPECTED_PREFIX}test-base-key")
+    group = described_class.new(key: 'test-key', name: 'Test')
+    expect(group.prefixed_key).to eq("#{EXPECTED_PREFIX}test-key")
   end
 
   it 'provides the name of the group' do
-    group = described_class.new(base_key: 'test-base-key', name: 'Test')
+    group = described_class.new(key: 'test-key', name: 'Test')
     expect(group.name).to eq('Test')
   end
 
@@ -240,61 +240,61 @@ describe UmdIPManager::Group do
     it 'raises an ArgumentError when given invalid parameters' do
       expect { described_class.new }.to raise_error(ArgumentError)
       expect { described_class.new(name: '') }.to raise_error(ArgumentError)
-      expect { described_class.new(base_key: '') }.to raise_error(ArgumentError)
-      expect { described_class.new(base_key: '', name: '') }.to raise_error(ArgumentError)
-      expect { described_class.new(base_key: 'foo', name: '') }.to raise_error(ArgumentError)
-      expect { described_class.new(base_key: '', name: 'Foo') }.to raise_error(ArgumentError)
+      expect { described_class.new(key: '') }.to raise_error(ArgumentError)
+      expect { described_class.new(key: '', name: '') }.to raise_error(ArgumentError)
+      expect { described_class.new(key: 'foo', name: '') }.to raise_error(ArgumentError)
+      expect { described_class.new(key: '', name: 'Foo') }.to raise_error(ArgumentError)
     end
 
     it 'is properly constructed when given valid parameters' do
-      group = described_class.new(base_key: 'test-base-key', name: 'Test')
-      expect(group.base_key).to eq('test-base-key')
+      group = described_class.new(key: 'test-key', name: 'Test')
+      expect(group.key).to eq('test-key')
       expect(group.name).to eq('Test')
-      expect(group.prefixed_key).to eq("#{EXPECTED_PREFIX}test-base-key")
+      expect(group.prefixed_key).to eq("#{EXPECTED_PREFIX}test-key")
     end
   end
 
   context '.as_prefixed_key' do
     context 'raises an ArgumentError' do
-      it 'when given a nil base_key' do
+      it 'when given a nil key' do
         expect { described_class.as_prefixed_key(nil) }.to raise_error(ArgumentError)
       end
 
-      it 'when given an empty base_key' do
+      it 'when given an empty key' do
         expect { described_class.as_prefixed_key('') }.to raise_error(ArgumentError)
       end
 
-      it 'when given an base_key of only whitespace' do
+      it 'when given an key of only whitespace' do
         expect { described_class.as_prefixed_key("  \t  ") }.to raise_error(ArgumentError)
       end
     end
 
-    it 'returns the given base_key prefixed with UmdIPManager::Group.PREFIX' do
+    it 'returns the given key prefixed with UmdIPManager::Group.PREFIX' do
       expect(described_class.as_prefixed_key('foo')).to eq("#{EXPECTED_PREFIX}foo")
     end
   end
 
-  context '.as_base_key' do
+  context '.as_key' do
     context 'raises an ArgumentError' do
       it 'when given a nil prefixed_key' do
-        expect { described_class.as_base_key(nil) }.to raise_error(ArgumentError)
+        expect { described_class.as_key(nil) }.to raise_error(ArgumentError)
       end
 
       it 'when given an empty prefixed_key' do
-        expect { described_class.as_base_key('') }.to raise_error(ArgumentError)
+        expect { described_class.as_key('') }.to raise_error(ArgumentError)
       end
 
       it 'when given a prefixed_key of only whitespace' do
-        expect { described_class.as_base_key("  \t  ") }.to raise_error(ArgumentError)
+        expect { described_class.as_key("  \t  ") }.to raise_error(ArgumentError)
       end
 
       it 'when given a prefixed_key without the expected prefix' do
-        expect { described_class.as_base_key("UNEXPECTED_PREFIX") }.to raise_error(ArgumentError)
+        expect { described_class.as_key("UNEXPECTED_PREFIX") }.to raise_error(ArgumentError)
       end
     end
 
     it 'returns the given prefixed_key without the UmdIPManager::Group.PREFIX' do
-      expect(described_class.as_base_key("#{EXPECTED_PREFIX}foo")).to eq('foo')
+      expect(described_class.as_key("#{EXPECTED_PREFIX}foo")).to eq('foo')
     end
   end
 


### PR DESCRIPTION
This work is based on the changes in [LIBAVALON-263](https://issues.umd.edu/browse/LIBAVALON-263).

* In the UmdIPManager class, the term "base_key" is potentially confusing, so changed it to simply "key" to match the data coming from IP Manager. The original intention was to distinguish between the "base_key" (from IP Manager) and the "prefixed_key" used in Avalon, but "key" is simpler, the distinction remains.
* Added default mock for UmdIPManager functionality. Because of the way the UmdIPManager functionality will be integrated into Avalon, calls to the IP Manager may occur in tests that are not directly related to UmdIPManager. To minimize the burden, modified the "spec/rails_helper.rb" class so that, by default, mock UmdIPManager functionality (via the "enable_umd_ip_manager_mock" method in "spec/services/mock_umd_ip_manager.rb" will be used that does not perform any network calls.
* Integrated UMD IP Manager groups into "Assign special access" for MediaObjects and Collections. This was done by adding a "UMD IP Manager" section to the "Assign special access" section of the views, and expanding the definition of "read_groups" in the various controllers and classes to include the UmdIPManager::Group names for storage in Fedora/Solr. Added "helper" functions to "app/helpers/application_helper.rb" to support converting UmdIPManager::Groups and leases into the appropriate human-readable name for display.
* Added code to handle the situation where the IP Manager cannot be contacted. In this case, an error banner is displayed in the "UMD IP Manager" section of "Assign special access". Note that when the IP Manager cannot be contacted, any UMD IP Manager groups added to a media object are not effective (i.e., it is as if the permission did not exist).
* Removed unused functionality from UmdIPManager, which as the "check_ip" and "ip_in_group?" methods, which are not used. Also removed access to the "key" field in UmdIPManager::Groups, as Avalon should always use the "prefixed_key" field, and removing it removes any ambiguity.

https://issues.umd.edu/browse/LIBAVALON-264