### PR TITLE
LIBAVALON-278. Sort collections A-Z on the /collections page.

### DIFF
--- a/app/javascript/components/CollectionList.js
+++ b/app/javascript/components/CollectionList.js
@@ -32,7 +32,7 @@ class CollectionList extends Component {
       searchResult: [],
       filteredResult: [],
       maxItems: 4,
-      sort: 'unit',
+      sort: props.sort ? props.sort : 'unit',
       isLoading: false
     };
   }

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -20,5 +20,5 @@ Unless required by applicable law or agreed to in writing, software distributed
     <h1 class="page-title">Collections</h1>
   </div>
 
-  <%= react_component("CollectionList", { baseUrl: collections_url(format: :json), filter: params['filter'] }) %>
+  <%= react_component("CollectionList", { baseUrl: collections_url(format: :json), sort: 'az', filter: params['filter'] }) %>
 </div>


### PR DESCRIPTION
- Added a "sort" parameter to the CollectionList constructor; retains stock Avalon behavior of defaulting to "unit" if no "sort" parameter is given
- Set the "sort" parameter to "az" on the collections index page

https://issues.umd.edu/browse/LIBAVALON-278