### PR TITLE
LIBAVALON-287. Updated UMD-README.md for M-series MacBooks

### DIFF
--- a/UMD-README.md
+++ b/UMD-README.md
@@ -9,37 +9,43 @@ UMD-generated documentation for Avalon should be placed in the
 
 ## Development Setup
 
-Prerequisite:
+### Prerequisites
 
-Edit the "/etc/hosts" file and add
+1) Edit the "/etc/hosts" file and add
 
 ```text
 127.0.0.1 av-local
 ```
 
+### Setup Instructions
+
+The following instructions include steps marked **(M-series)** which are
+required when setting up and running Avalon on M-series (Apple Silicon)
+MacBooks. These steps can be ignored when running on other platforms.
+
 1) Checkout the application and swtich to the directory:
 
-    ```bash
+    ```zsh
     git clone git@github.com:umd-lib/avalon.git
     cd avalon
     ```
 
 2) Copy the "env_template" file to ".env":
 
-    ``` bash
+    ``` zsh
     cp env_template .env
     ```
 
 3) Edit the '.env" file:
 
-    ```bash
+    ```zsh
     vi .env
     ```
 
 4) (Required) Determine the values for the "SAML_SP_PRIVATE_KEY" and
     "SAML_SP_CERTIFICATE" variables:
 
-    ```bash
+    ```zsh
     kubectl -n test get secret avalon-common-env-secret -o jsonpath='{.data.SAML_SP_PRIVATE_KEY}' | base64 --decode
     kubectl -n test get secret avalon-common-env-secret -o jsonpath='{.data.SAML_SP_CERTIFICATE}' | base64 --decode
     ```
@@ -60,10 +66,51 @@ Edit the "/etc/hosts" file and add
 * IP_MANAGER_SERVER_URL - URL of the IP Manager server (i.e.,
     <https://ipmanager-test.lib.umd.edu>)
 
-6) Start the server
+6) **(M-series)** Edit the "config/environments/development.rb" file:
+
+    ```zsh
+    vi config/environments/development.rb
+    ```
+
+    and commenting out the line:
+
+    ```text
+    config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+    ```
+
+    by changing it to:
+
+    ```text
+    # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+    ```
+
+7) Retrieve the Docker images necessary to run Avalon:
+
+    ```zsh
+    docker-compose pull
+    ```
+
+8) **(M-series)** Build the "avalonmediasystem/fedora:4.7.5" for the "arm64"
+   architecture:
+
+    a) In a separate terminal and directory, clone the
+      "avalonmediasystem/avalon-docker" GitHub repository and switch into the
+      directory:
+
+      ```zsh
+      git clone https://github.com/avalonmediasystem/avalon-docker.git
+      cd avalon-docker/fedora
+      ```
+
+    b) Build the "avalonmediasystem/fedora:4.7.5" Docker image:
+
+      ```zsh
+      docker build -t avalonmediasystem/fedora:4.7.5 .
+      ```
+
+7) Start the server
 
     ```bash
-    docker-compose pull
     docker-compose up avalon worker
     ```
 
@@ -79,17 +126,21 @@ The following variables were added to facilate configuring environment
 specific SAML configuration. These environment varaibles will take
 precedence over the configuration in the [settings.yml](./config/settings.yml).
 
-- `SAML_ISSUER`: Overrides the `issuer` configuration.
-- `SAML_SP_PRIVATE_KEY`: Overrides the `private_key` configuration.
-- `SAML_SP_CERTIFICATE`: Overrides the `certificate` configuration.
+* `SAML_ISSUER`: Overrides the `issuer` configuration.
+* `SAML_SP_PRIVATE_KEY`: Overrides the `private_key` configuration.
+* `SAML_SP_CERTIFICATE`: Overrides the `certificate` configuration.
 
 ## Docker Build for K8s Deployment
 
 The k8s-avalon stack uses the avalon image built from this repository.
 
+**Note:** On M-series MacBooks, the Docker images should be built in the
+Kubernetes cluster to ensure that they have the correct architecture. See
+<https://github.com/umd-lib/k8s/blob/main/docs/DockerBuilds.md>.
+
 1. Build and tag the image
 
-    ```bash
+    ```zsh
     # Substitute IMAGE_TAG with appropriate value
     # Example IMAGE_TAG values for differnt scenarios:
     #    Dev Build: docker.lib.umd.edu/avalon:latest
@@ -101,7 +152,7 @@ The k8s-avalon stack uses the avalon image built from this repository.
 
 2. Push it to UMD Nexus
 
-    ```bash
+    ```zsh
     # Substitute IMAGE_TAG with appropriate value
     docker push IMAGE_TAG
     ```
@@ -130,13 +181,13 @@ are missing.
 To perform a "dry run", use a "dry_run" environment variable (lower-case,
 because lower-case is used in supplying arguments to other Avalon Rake tasks):
 
-```bash
+```zsh
 dry_run=true rails umd:move_dropbox_files_to_archive
 ```
 
 To perform the actual migration:
 
-```bash
+```zsh
 rails umd:move_dropbox_files_to_archive
 ```
 

--- a/UMD-README.md
+++ b/UMD-README.md
@@ -108,6 +108,11 @@ MacBooks. These steps can be ignored when running on other platforms.
       docker build -t avalonmediasystem/fedora:4.7.5 .
       ```
 
+    c) Close the terminal (the directory containing the
+       "avalonmediasystem/avalon-docker" checkout can also be deleted, if
+       desired). The remaining steps should be done in the original
+       terminal and directory with the "umd-lib/avalon" checkout.
+
 7) Start the server
 
     ```bash


### PR DESCRIPTION
Updated the "Development Setup" instructions with the additional steps needed to run Avalon on an M-series (Apple Silicon) MacBook.

https://umd-dit.atlassian.net/browse/LIBAVALON-287