### PR TITLE
LIBAVALON-312. Replaced Google Analytics with Matomo Analytics

### DIFF
--- a/UMD-README.md
+++ b/UMD-README.md
@@ -83,6 +83,22 @@ precedence over the configuration in the [settings.yml](./config/settings.yml).
 - `SAML_SP_PRIVATE_KEY`: Overrides the `private_key` configuration.
 - `SAML_SP_CERTIFICATE`: Overrides the `certificate` configuration.
 
+## Matomo Analytics
+
+The UMD instance of Avalon uses Matomo Analytics (<https://matomo.org/>) for
+tracking user activity.
+
+Matomo tracking is enabled when all of the following environment variables are
+configured with the appropriate values, which can be obtained from the
+"Digital Collection - Audiovisual (Avalon)" website configuration on the UMD
+Matomo dashboard:
+
+* MATOMO_ANALYTICS_URL - URL of the UMD Matomo website
+* MATOMO_ANALYTICS_SITE_ID - The Matomo-provided site id
+* MATOMO_ANALYTICS_CDN_SRC = CDN URL to the UMD Matomo JavaScript script
+
+If any of the values are not provided, Matomo tracking will be disabled.
+
 ## Docker Build for K8s Deployment
 
 The k8s-avalon stack uses the avalon image built from this repository.

--- a/app/views/layouts/avalon.html.erb
+++ b/app/views/layouts/avalon.html.erb
@@ -20,7 +20,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <title><%= render_page_title %></title>
-  
+
   <meta property="og:title" content="<%= render_page_title %>" />
   <meta property="og:type" content=<%= @page_type || "website" %> />
   <meta property="og:url" content=<%= request.url %> />
@@ -78,16 +78,6 @@ Unless required by applicable law or agreed to in writing, software distributed
          from a CDN -->
   <%= javascript_include_tag "application" %>
   <%= yield :page_scripts %>
-
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV['GTAG_ID'] %>"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', '<%= ENV['GTAG_ID'] %>');
-  </script> 
 
   <!-- UMD Wrapper -->
   <script src="https://umd-header.umd.edu/build/bundle.js?search=0&search_domain=&events=0&news=0&schools=0&admissions=0&support=1&support_url=https%253A%252F%252Fwww.lib.umd.edu%252Fabout%252Fgiving&wrapper=1160&sticky=0"></script>

--- a/app/views/layouts/avalon.html.erb
+++ b/app/views/layouts/avalon.html.erb
@@ -37,6 +37,10 @@ Unless required by applicable law or agreed to in writing, software distributed
   <%= yield :page_styles %>
   <%= yield :additional_head_content %>
   <%= render "modules/google_analytics" %>
+
+  <!-- UMD Customization -->
+  <%= render "modules/matomo_analytics" %>
+  <!-- End UMD Customization -->
 </head>
 
 <body data-mountpoint="<%=main_app.root_path%>">

--- a/app/views/layouts/embed.html.erb
+++ b/app/views/layouts/embed.html.erb
@@ -31,6 +31,9 @@ Unless required by applicable law or agreed to in writing, software distributed
     <%= yield :page_styles %>
     <%= yield :additional_head_content %>
     <%= render "modules/google_analytics" %>
+    <!-- UMD Customization -->
+    <%= render "modules/matomo_analytics" %>
+    <!-- End UMD Customization -->
   </head>
 
   <body>

--- a/app/views/modules/_matomo_analytics.html.erb
+++ b/app/views/modules/_matomo_analytics.html.erb
@@ -1,0 +1,24 @@
+<%# This is a UMD added file for supporting Matomo Analytics %>
+<%
+  matomo_env_config_available = ENV['MATOMO_ANALYTICS_URL'].present? &&
+    ENV['MATOMO_ANALYTICS_SITE_ID'].present? &&
+    ENV['MATOMO_ANALYTICS_CDN_SRC'].present?
+%>
+
+<% if matomo_env_config_available %>
+  <!-- Matomo -->
+  <script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="<%= ENV['MATOMO_ANALYTICS_URL'] %>";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', "<%= ENV['MATOMO_ANALYTICS_SITE_ID'] %>"]);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src="<%= ENV['MATOMO_ANALYTICS_CDN_SRC'] %>"; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo Code -->
+<% end %>

--- a/env_template
+++ b/env_template
@@ -18,3 +18,8 @@ UMD_HANDLE_JWT_TOKEN=
 
 # IP Manager Configuration
 IP_MANAGER_SERVER_URL=
+
+# Matomo Analytics configuration
+MATOMO_ANALYTICS_URL=https://umd.matomo.cloud/
+MATOMO_ANALYTICS_SITE_ID=
+MATOMO_ANALYTICS_CDN_SRC= //cdn.matomo.cloud/umd.matomo.cloud/matomo.js

--- a/spec/views/matomo_analytics_spec.rb
+++ b/spec/views/matomo_analytics_spec.rb
@@ -1,0 +1,41 @@
+# This is a UMD-added file
+require 'rails_helper'
+
+describe "modules/_matomo_analytics.html.erb", type: :view do
+  context "Matomo Analytics environment variables are configured" do
+    before do
+      ENV['MATOMO_ANALYTICS_URL'] = 'https://test.example.cloud/'
+      ENV['MATOMO_ANALYTICS_SITE_ID'] = '14'
+      ENV['MATOMO_ANALYTICS_CDN_SRC'] = '//test.example.cloud/umd.matomo.cloud/matomo.js'
+    end
+
+    it 'has Matomo script when all environment variables are configured' do
+      render
+      expect(has_matomo_script?).to be true
+    end
+
+    it 'does not have Matomo script if "MATOMO_ANALYTICS_URL" enviroment variable is not configured' do
+      ENV['MATOMO_ANALYTICS_URL'] = nil
+      render
+      expect(has_matomo_script?).to be false
+    end
+
+    it 'does not have Matomo script if "MATOMO_ANALYTICS_SITE_ID" enviroment variable is not configured' do
+      ENV['MATOMO_ANALYTICS_SITE_ID'] = ''
+      render
+      expect(has_matomo_script?).to be false
+    end
+
+    it 'does not have Matomo script if "MATOMO_ANALYTICS_CDN_SRC" enviroment variable is not configured' do
+      ENV.delete('MATOMO_ANALYTICS_CDN_SRC')
+      render
+      expect(has_matomo_script?).to be false
+    end
+  end
+
+  # Returns true if the Matomo script is present in the "rendered" string,
+  # false otherwise.
+  def has_matomo_script?
+    rendered.include?('var _paq = window._paq = window._paq || [];')
+  end
+end


### PR DESCRIPTION
1) Removed the “Google Analytics” script added by UMD to the “app/views/layouts/avalon.html.erb” file in LIBAVALON-109

2) Added three environment variables to the "env_template" file to control the settings in the Matomo Analytics JavaScript script:

* MATOMO_ANALYTICS_URL - URL of the UMD Matomo website
* MATOMO_ANALYTICS_SITE_ID - The Matomo-provided site id
* MATOMO_ANALYTICS_CDN_SRC = CDN URL to the UMD Matomo JavaScript script

Intentionally left the "MATOMO_ANALYTICS_SITE_ID" environment variable empty to prevent Matomo tracking in local development.

3) Added a "matomo_analytics" view partial in "app/views/modules/_matomo_analytics.html.erb" containing the Matomo Analytics JavaScript from the Matomo website, modified to use the environment variables. In the partial, the script is not added if any of the environment variables are missing.

Added a unit test for the "matomo_analytics" view partial.

4) Added the "matomo_analytics" view partial to the same "layouts" files that contain the "google_analytics" view partial.

5) Updated the UMD-README.md with information about Matomo Analytics.

https://umd-dit.atlassian.net/browse/LIBAVALON-312