### PR TITLE
LIBAVALON-316: Updating known issues to mention change of umd handle url

### DIFF
--- a/UMD-README.md
+++ b/UMD-README.md
@@ -71,6 +71,12 @@ Avalon should be available at: [http://av-local:3000](http://av-local:3000)
 
 **Known issue**:  Both, umd-handle web app and avalon web app use SAML certificates that require them to run on port 3000. When testing Avalon integration with umd-handle, run the umd-handle server on a different port (e.g. 3001). As Avalon uses JWT authentication to talk to the umd-handle REST API, the umd-handle integration can be tested without requiring a working SAML setup for umd-handle.
 
+The host name will also need to be configured if umd-handle is not being run through docker, since both will be on different networks. So in the .env file the handle server url should be:
+
+```bash
+UMD_HANDLE_SERVER_URL=http://host.docker.internal:3001/api/v1/handles
+```
+
 See [Readme](./README.md#Development) for more information.
 
 ## SAML Environment Specific Configuration

--- a/UMD-README.md
+++ b/UMD-README.md
@@ -77,6 +77,21 @@ The host name will also need to be configured if umd-handle is not being run thr
 UMD_HANDLE_SERVER_URL=http://host.docker.internal:3001/api/v1/handles
 ```
 
+And config/application.rb in UMD-Handles should be updated to allow the host:
+
+```bash
+# HOST should be ignored (and config.hosts not set) when running the tests.
+    if ENV['HOST'].present? && !Rails.env.test?
+      config.hosts << /\A10\.\d+\.\d+\.\d+\z/
+      config.hosts << ENV['HOST']
+      config.hosts << ENV['K8S_INTERNAL_HOST'] if ENV['K8S_INTERNAL_HOST']
+      config.action_mailer.default_url_options = { host: ENV['HOST'] }
+    end
+
+    ### Add this line here ###
+    config.hosts << 'host.docker.internal'
+```
+
 See [Readme](./README.md#Development) for more information.
 
 ## SAML Environment Specific Configuration


### PR DESCRIPTION
Updating the README to note that the host name should be host.docker.internal when Avalon is being run in docker and the Handle Service isn't.

https://umd-dit.atlassian.net/browse/LIBAVALON-316