### PR TITLE
LIBAVALON-330. Disable hidden fields in multipart dropdown.

### DIFF
--- a/app/views/media_objects/_multipart_dropdown_field.html.erb
+++ b/app/views/media_objects/_multipart_dropdown_field.html.erb
@@ -18,7 +18,7 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 <div class="input-group-prepend">
   <% fieldname = "media_object[#{options[:dropdown_field]}]#{fieldarray}" %>
-  <%= hidden_field_tag fieldname, selected_value %>
+  <%= hidden_field_tag fieldname, selected_value, :disabled => "true" %>
   <% option_hash = (options[:dropdown_options].values).zip(options[:dropdown_options].keys) %>
   <%= select_tag fieldname.to_s, options_for_select(option_hash, selected_value) %>
 </div>


### PR DESCRIPTION
The hidden inputs no longer seems to be used, and it is removed in Avalon 7.6. The hidden inputs were causing the form to include previous state in addition to the updated values.

https://umd-dit.atlassian.net/browse/LIBAVALON-330