### PR TITLE
LIBAVALON-342. Allow manager or editor to add a transcript file.

### DIFF
--- a/app/controllers/supplemental_files_controller.rb
+++ b/app/controllers/supplemental_files_controller.rb
@@ -145,7 +145,8 @@ class SupplementalFilesController < ApplicationController
     end
 
     def authorize_object
-      action = action_name.to_sym
+      action = action_name.to_sym == :show ? :show : :edit
+      # Only display supplemental files if user has full_read permission
       action = :full_read if action == :show && @object.is_a?(MediaObject)
       authorize! action, @object, message: "You do not have sufficient privileges to #{action_name} this supplemental file"
     end


### PR DESCRIPTION
Copied fix from upstream Avalon: https://github.com/avalonmediasystem/avalon/commit/548d9240e144f54f8c6ba92b12854b2ad57598cf

https://umd-dit.atlassian.net/browse/LIBAVALON-342