### PR TITLE
LIBAVALON-333. Fix timeline index page.

### DIFF
--- a/app/views/modules/_footer.html.erb
+++ b/app/views/modules/_footer.html.erb
@@ -13,57 +13,61 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
-<footer>  
-  <div style="background: #111;">
-  <div class="subfooter" >
+<div id="footer">
+
+  <footer>  
+    <div style="background: #111;">
+    <div class="subfooter" >
+      <div class="container">
+        <div class="row">
+          <div class="col-md-5">
+            <div class="headline">
+            <h2>About</h2>
+            </div>
+
+            <p>This site includes a selection of digital audio and video materials currently available from the holdings of the University of Maryland Libraries, and represents only a portion of our digital content. Please visit the main <a href="https://digital.lib.umd.edu">Digital Collections</a> site to explore more digital content, including photographs, manuscripts, newspapers, and more material.</p>
+
+            <p>A small portion of our unique collections have been digitized and many more materials can be accessed by visiting our Libraries.</p>
+          </div>
+
+          <div class="col-md-5">
+            <div class="headline">
+              <h2>Contact Us</h2>
+            </div>
+
+            <p>Librarians are available to help you at any point in your research project. We can be reached by phone, email or in person.&nbsp;</p>
+
+            <p>University of Maryland Libraries<br>
+            College Park, MD 20742</p>
+
+            <p>Digital Collections is a project of Digital Programs &amp; Initiatives. <a href="https://libumd.wufoo.com/forms/digitalfeedback/">Contact Us</a></p>
+          </div>
+          
+          <div class="col-md-2">
+            <div class="headline">
+              <h2>Stay Connected</h2>
+            </div>
+            <ul class="social-icons">
+            <li><a class="social_rss" data-original-title="Feed" href="https://hornbakelibrary.wordpress.com/" target="_blank">.</a></li>
+            <li><a class="social_facebook" data-original-title="Facebook" href="https://www.facebook.com/HornbakeLibrary" target="_blank">.</a></li>
+            <li><a class="social_twitter" data-original-title="Twitter" href="https://twitter.com/hornbakelibrary" target="_blank">.</a></li>
+            <li><a class="social_pintrest" data-original-title="Pinterest" href="https://www.pinterest.com/speccollumd/" target="_blank">.</a></li>
+            </ul>
+
+          </div>
+      </div>
+    </div>
+    </div>
     <div class="container">
-      <div class="row">
-        <div class="col-md-5">
-          <div class="headline">
-          <h2>About</h2>
-          </div>
-
-          <p>This site includes a selection of digital audio and video materials currently available from the holdings of the University of Maryland Libraries, and represents only a portion of our digital content. Please visit the main <a href="https://digital.lib.umd.edu">Digital Collections</a> site to explore more digital content, including photographs, manuscripts, newspapers, and more material.</p>
-
-          <p>A small portion of our unique collections have been digitized and many more materials can be accessed by visiting our Libraries.</p>
-        </div>
-
-        <div class="col-md-5">
-          <div class="headline">
-            <h2>Contact Us</h2>
-          </div>
-
-          <p>Librarians are available to help you at any point in your research project. We can be reached by phone, email or in person.&nbsp;</p>
-
-          <p>University of Maryland Libraries<br>
-          College Park, MD 20742</p>
-
-          <p>Digital Collections is a project of Digital Programs &amp; Initiatives. <a href="https://libumd.wufoo.com/forms/digitalfeedback/">Contact Us</a></p>
-        </div>
-        
-        <div class="col-md-2">
-          <div class="headline">
-            <h2>Stay Connected</h2>
-          </div>
-          <ul class="social-icons">
-           <li><a class="social_rss" data-original-title="Feed" href="https://hornbakelibrary.wordpress.com/" target="_blank">.</a></li>
-           <li><a class="social_facebook" data-original-title="Facebook" href="https://www.facebook.com/HornbakeLibrary" target="_blank">.</a></li>
-           <li><a class="social_twitter" data-original-title="Twitter" href="https://twitter.com/hornbakelibrary" target="_blank">.</a></li>
-           <li><a class="social_pintrest" data-original-title="Pinterest" href="https://www.pinterest.com/speccollumd/" target="_blank">.</a></li>
-          </ul>
-
-        </div>
+      <div class="row copyright">
+        <p>
+          <a href="//giving.umd.edu/giving/showSchool.php?name=libraries">Give Now</a> |
+          <a href="https://www.lib.umd.edu/about/policies/privacy">Privacy Policy</a> |
+          <a href="https://www.umd.edu/web-accessibility">Web Accessibility</a>
+        </p>
+      </div>
     </div>
-  </div>
-  </div>
-  <div class="container">
-    <div class="row copyright">
-      <p>
-        <a href="//giving.umd.edu/giving/showSchool.php?name=libraries">Give Now</a> |
-        <a href="https://www.lib.umd.edu/about/policies/privacy">Privacy Policy</a> |
-        <a href="https://www.umd.edu/web-accessibility">Web Accessibility</a>
-      </p>
     </div>
-  </div>
-  </div>
-</footer>
+  </footer>
+
+</div>


### PR DESCRIPTION
The missing footer container div was cuasing the footer to overlap with the timeline divs. Fixed it by adding the footer container div.

https://umd-dit.atlassian.net/browse/LIBAVALON-333