### PR TITLE
LIBAVALON-332. Fix ujs event handlers

### DIFF
--- a/app/assets/javascripts/avalon_playlists/playlists.js.coffee
+++ b/app/assets/javascripts/avalon_playlists/playlists.js.coffee
@@ -57,7 +57,8 @@ $('#playlist_title').on('keyup',
 )
 
 $('#copy-playlist-form').bind('ajax:success',
-  (event, data, status, xhr) ->
+  (event) ->
+    [data, status, xhr] = event.detail;
     if (data.errors)
       console.log(data.errors.title[0])
     else
@@ -67,7 +68,8 @@ $('#copy-playlist-form').bind('ajax:success',
         if ( $('#with_refresh').val() )
           location.reload()
 ).bind('ajax:error',
-  (e, xhr, status, error) ->
+  (event) ->
+    [data, status, xhr] = event.detail;
     console.log(xhr.responseJSON.errors)
 )
 

--- a/app/assets/javascripts/avalon_timelines/timelines.js.coffee
+++ b/app/assets/javascripts/avalon_timelines/timelines.js.coffee
@@ -65,7 +65,8 @@ $('#copy-timeline-form').submit(
 )
 
 $('#copy-timeline-form').bind('ajax:success',
-  (event, data, status, xhr) ->
+  (event) ->
+    [data, status, xhr] = event.detail;
     if (data.errors)
       console.log(data.errors.title[0])
     else
@@ -75,7 +76,8 @@ $('#copy-timeline-form').bind('ajax:success',
         if ( $('#with_refresh').val() )
           location.reload()
 ).bind('ajax:error',
-  (e, xhr, status, error) ->
+  (event) ->
+    [data, status, xhr] = event.detail;
     console.log(xhr.responseJSON.errors)
 )
 

--- a/app/assets/javascripts/supplemental_files.js
+++ b/app/assets/javascripts/supplemental_files.js
@@ -55,7 +55,7 @@ $('button[name="save_label"]').on('click', (e) => {
 
 /* Show feedback message inline after saving */
 $('.supplemental-file-form')
-  .on('ajax:success', (event, data, status, xhr) => {
+  .on('ajax:success', (event) => {
     var $row = $(event.currentTarget.parentElement);
     const { masterfileId, fileId } = event.currentTarget.dataset;
 
@@ -77,7 +77,7 @@ $('.supplemental-file-form')
     $row.find('.visible-inline').html('Successfully updated.');
     $row.find('.visible-inline').addClass('alert');
   })
-  .on('ajax:error', (event, xhr, status, error) => {
+  .on('ajax:error', (event) => {
     var alert = $(event.currentTarget.parentElement).find('.visible-inline');
 
     // Show flash warning for failed attempt

--- a/app/views/media_objects/_file_upload.html.erb
+++ b/app/views/media_objects/_file_upload.html.erb
@@ -316,9 +316,9 @@ Unless required by applicable law or agreed to in writing, software distributed
       $(this).closest('form').submit();
     });
 
-    $('.master-file-form').on("ajax:success", (event, data, status, xhr) => {
+    $('.master-file-form').on("ajax:success", (event) => {
       $(event.currentTarget).find('.flash-message').html("Successfully updated.")
-    }).on("ajax:error", (event, xhr, status, error) => {
+    }).on("ajax:error", (event) => {
       $(event.currentTarget).find('.flash-message').html("Failed to update.")
     });
   </script>

--- a/app/views/playlists/refresh_info.js.erb
+++ b/app/views/playlists/refresh_info.js.erb
@@ -46,7 +46,7 @@ $('.marker_title').click(function(e) {
     currentPlayer.setCurrentTime(parseFloat(this.dataset['offset']) || 0);
   }
 });
-$('.edit_avalon_marker').on('ajax:success', handle_edit_save).on('ajax:error', function(e, xhr, status, error) {
+$('.edit_avalon_marker').on('ajax:success', handle_edit_save).on('ajax:error', function(e) {
   alert('Request failed.');
 });
 $('button[name="delete_marker"]').popover({


### PR DESCRIPTION
With Rails 6, the ajax event handler signature changed to only include "event" arg. All the other args are included in the event.detail property.

Reference: https://guides.rubyonrails.org/v6.1.0/working_with_javascript_in_rails.html#rails-ujs-event-handlers

https://umd-dit.atlassian.net/browse/LIBAVALON-332