### PR TITLE
LIBAVALON-379 / LIBAVALON-383: Adding Dummy Email and Using Embed Media Player for LTI Users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2023, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -92,6 +92,21 @@ class ApplicationController < ActionController::Base
       root_path
     end
   end
+
+  # UMD Customization
+  def lti_redirect_url(auth_type, lti_group: nil)
+    # callback URL goes to 'section/:content'
+    # and we want to redirect to '/master_files/%{content}/embed'
+    # reference the media object route in routes.rb
+    if params['target_id'] && ((fetch_object(params['target_id'])).is_a? MasterFile)
+      logger.debug "Getting embed URL for master file"
+      "/master_files/" + params['target_id'] + "/embed"
+    else
+      logger.debug "Getting regular LTI Redirect URL"
+      find_redirect_url(auth_type, lti_group: lti_group)
+    end
+  end
+  # End UMD Customization
 
   def handle_api_request
     if request.headers['Avalon-Api-Key'].present?

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2023, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -88,7 +88,9 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       flash[:success] = nil
       render inline: '<html><head><script>window.close();</script></head><body></body><html>'.html_safe
     else
-      redirect_to find_redirect_url(auth_type, lti_group: user_session&.dig(:lti_group))
+      # UMD Customization
+      redirect_to lti_redirect_url(auth_type, lti_group: user_session&.dig(:lti_group))
+      # End UMD Customization
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2023, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -178,10 +178,13 @@ class User < ActiveRecord::Base
       Course.create :context_id => class_id, :label => auth_hash.extra.consumer.context_label, :title => class_name unless class_name.nil?
     end
 
-    # Canvas does not provide an email in the LTI information, so we need to use a dummy one
-    # created based on the context_id and the streaming hostname
-    email = auth_hash.info.email || class_id + '@' ENV['STREAMING_HOST']
-    find_or_create_by_username_or_email(auth_hash.uid, email, 'lti')
+    # UMD Customization
+    # Creating a dummy email based on the context_id and the streaming hostname (Canvas doesn't provide an email)
+    email = auth_hash.info.email || class_id + '@' + ENV['STREAMING_HOST']
+    # Using the context_label (Course Name) as the username to be more readable
+    username = auth_hash.extra.context_label
+    find_or_create_by_username_or_email(username, email, 'lti')
+    # End UMD Customization
   end
 
   def self.autocomplete(query)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -178,7 +178,10 @@ class User < ActiveRecord::Base
       Course.create :context_id => class_id, :label => auth_hash.extra.consumer.context_label, :title => class_name unless class_name.nil?
     end
 
-    find_or_create_by_username_or_email(auth_hash.uid, auth_hash.info.email, 'lti')
+    # Canvas does not provide an email in the LTI information, so we need to use a dummy one
+    # created based on the context_id and the streaming hostname
+    email = auth_hash.info.email || class_id + '@' ENV['STREAMING_HOST']
+    find_or_create_by_username_or_email(auth_hash.uid, email, 'lti')
   end
 
   def self.autocomplete(query)

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -7,8 +7,8 @@ Avalon::Application.config.session_store :active_record_store,
   # Use "Lax" SameSite for local development because UMD uses "av-local" instead
   # of "localhost" for the hostname. Without this, cannot log in using Firefox.
   same_site: (Rails.env.development? ? "Lax" : "None"),
+  httponly: false,
   # End UMD Customization
-  httponly: true,
   expire_after: 2.weeks
 
 # Use the database for sessions instead of the cookie-based default,


### PR DESCRIPTION
- Fixes sign-in issue due to Canvas not providing an email
- When an LTI user is incoming, redirects the user to the embedded media player, so that it can be rendered within Canvas

https://umd-dit.atlassian.net/browse/LIBAVALON-379
https://umd-dit.atlassian.net/browse/LIBAVALON-383