### PR TITLE
LIBAVALON-385: Add Dockerfile.dev to speed up build times

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,4 @@
+FROM docker.lib.umd.edu/avalon:<your_tag>
+
+COPY <path> avalon<path>
+...


### PR DESCRIPTION
The idea is to build a initial docker image that you reuse, where you just copy the files you need to change, instead of building the whole image from scratch every time.

https://umd-dit.atlassian.net/browse/LIBAVALON-385