### PR TITLE
LIBAVALON-388. Restrict access token creation.

### DIFF
--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -11,6 +11,7 @@ class AccessToken < ApplicationRecord
   validate :user_must_be_collection_member
   # UMD Customization
   validate :media_object_not_in_streaming_reserves_unit
+  validate :media_object_is_published
   # End UMD Customization
 
   after_create :add_read_group
@@ -101,6 +102,7 @@ class AccessToken < ApplicationRecord
     end
   end
 
+  # UMD Customization
   # Validation method to check whether the media object is in the
   # streaming reserves unit. If it is, it adds an error to the media_object_id.
   def media_object_not_in_streaming_reserves_unit
@@ -111,6 +113,17 @@ class AccessToken < ApplicationRecord
       end
     end
   end
+
+  def media_object_is_published
+    if media_object_id.present? && media_object_exists?
+      media_object = MediaObject.find(media_object_id)
+      if media_object&.published? == false
+        errors.add(:media_object_id, 'is not published and cannot be accessed with a token.')
+      end
+    end
+  end
+
+  # End UMD Customization
 
   # Validation method to check whether the user creating this token is an admin
   # or "member" (manager, editor, or depositor) of the collection holding the

--- a/app/models/access_token.rb
+++ b/app/models/access_token.rb
@@ -9,6 +9,9 @@ class AccessToken < ApplicationRecord
   validates :expiration, presence: true
   validate :expiration_must_be_future
   validate :user_must_be_collection_member
+  # UMD Customization
+  validate :media_object_not_in_streaming_reserves_unit
+  # End UMD Customization
 
   after_create :add_read_group
 
@@ -95,6 +98,17 @@ class AccessToken < ApplicationRecord
   def media_object_must_exist
     if media_object_id.present?
       errors.add(:media_object_id, 'not found') unless media_object_exists?
+    end
+  end
+
+  # Validation method to check whether the media object is in the
+  # streaming reserves unit. If it is, it adds an error to the media_object_id.
+  def media_object_not_in_streaming_reserves_unit
+    if media_object_id.present? && media_object_exists?
+      media_object = MediaObject.find(media_object_id)
+      if media_object&.collection&.unit == Settings.streaming_reserves.unit_name
+        errors.add(:media_object_id, 'is in the streaming reserves unit and cannot be accessed with a token.')
+      end
     end
   end
 

--- a/config/controlled_vocabulary.yml.example
+++ b/config/controlled_vocabulary.yml.example
@@ -1,5 +1,8 @@
 units:
   - Default Unit
+  # End UMD Customization
+  - Streaming Reserves
+  # End UMD Customization
 identifier_types:
   local: Catalog Key
   oclc: OCLC

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -136,3 +136,7 @@ caption_default:
   # Language should be 2 or 3 letter ISO 639 codes
   language: 'en'
   name: 'English'
+# UMD Customization
+streaming_reserves:
+  unit_name: 'Streaming Reserves'
+# End UMD Customization


### PR DESCRIPTION
- Prevent access token creation for streaming reserves items.
- Disallow token creation for unpublished items.

https://umd-dit.atlassian.net/browse/LIBAVALON-388
https://umd-dit.atlassian.net/browse/LIBAVALON-279