### PR TITLE
LIBAVALON-394. Backport of 8.0 changes to collection_presenter.rb

### DIFF
--- a/app/presenters/admin/collection_presenter.rb
+++ b/app/presenters/admin/collection_presenter.rb
@@ -44,15 +44,24 @@ class Admin::CollectionPresenter
   end
 
   def managers
-    @managers ||= document["edit_access_person_ssim"] & (document["collection_managers_ssim"] || [])
+    # UMD Customization
+    # Backport of Avalon 8.0 change
+    @managers ||= Array(document["edit_access_person_ssim"]) & Array(document["collection_managers_ssim"])
+    # End UMD Customization
   end
 
   def editors
-    @editors ||= document["edit_access_person_ssim"] - managers
+    # UMD Customization
+    # Backport of Avalon 8.0 change
+    @editors ||= Array(document["edit_access_person_ssim"]) - managers
+    # End UMD Customization
   end
 
   def depositors
-    document["read_access_person_ssim"]
+    # UMD Customization
+    # Backport of Avalon 8.0 change
+    Array(document["read_access_person_ssim"])
+    # End UMD Customization
   end
 
   def manager_count


### PR DESCRIPTION
When running in the Kubernetes "sandbox" the going to https://av.sandbox.lib.umd.edu/admin/collections
would fail with the following error in the Avalon log:

```
avalon-0 avalon F, [2025-07-15T18:43:43.508757 #20] FATAL -- : [2f999136bc4cdf98514a88b73bd13430]
avalon-0 avalon [2f999136bc4cdf98514a88b73bd13430] ActionView::Template::Error (undefined method `size' for false:FalseClass):
avalon-0 avalon [2f999136bc4cdf98514a88b73bd13430]     50:           <%=link_to("(#{collection.unpublished_media_object_count} unpublished)", search_catalog_path('f[collection_ssim][]' => collection.name, 'f[workflow_published_sim][]' => "Unpublished")) %>
avalon-0 avalon [2f999136bc4cdf98514a88b73bd13430]     51:           <% end %>
avalon-0 avalon [2f999136bc4cdf98514a88b73bd13430]     52:         </td>
avalon-0 avalon [2f999136bc4cdf98514a88b73bd13430]     53:         <td> <%= pluralize(collection.manager_count, 'manager') %> </td>
avalon-0 avalon [2f999136bc4cdf98514a88b73bd13430]     54:         <td> <%= collection.description&.truncate(100, separator: ' ') %> </td>
avalon-0 avalon [2f999136bc4cdf98514a88b73bd13430]     55:         <td class="text-right">
avalon-0 avalon [2f999136bc4cdf98514a88b73bd13430]     56:           <% if can?(:destroy, collection) %>
avalon-0 avalon [2f999136bc4cdf98514a88b73bd13430]
avalon-0 avalon [2f999136bc4cdf98514a88b73bd13430] app/presenters/admin/collection_presenter.rb:59:in `manager_count'
avalon-0 avalon [2f999136bc4cdf98514a88b73bd13430] app/views/admin/collections/index.html.erb:53
avalon-0 avalon [2f999136bc4cdf98514a88b73bd13430] app/views/admin/collections/index.html.erb:44:in `each'
avalon-0 avalon [2f999136bc4cdf98514a88b73bd13430] app/views/admin/collections/index.html.erb:44
avalon-0 avalon [2f999136bc4cdf98514a88b73bd13430] config/initializers/ldp_solr_duration_logger.rb:35:in `cleanup_view_runtime'
avalon-0 avalon [2f999136bc4cdf98514a88b73bd13430] config/initializers/ldp_solr_duration_logger.rb:25:in `process_action'
avalon-0 avalon [2f999136bc4cdf98514a88b73bd13430] lib/tempfile_factory.rb:22:in `call'
```

This appears to occur where this is a collection without a collection manager (which is likely uncommon, but happening in the Kubernetes "sandbox" because it has very few items).

Backporting this change from
Git commit 51c7e1fb121c394909576b14b0acda40b54f3e17 in Avalon 8.0 from stock Avalon fixes the issue.

https://umd-dit.atlassian.net/browse/LIBAVALON-394