### PR TITLE
LIBAVALON-377. Prevent handle creation for streaming reserves items.

### DIFF
--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2024, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -465,6 +465,12 @@ class MediaObject < ActiveFedora::Base
 
     search_array.map { |value| { id: value, display: value } }
   end
+  
+  # UMD Customization
+  def is_streaming_reserve?
+    collection&.unit == Settings.streaming_reserves.unit_name
+  end
+  # End UMD Customization
 
   private
 

--- a/config/initializers/generate_permalink.rb
+++ b/config/initializers/generate_permalink.rb
@@ -1,6 +1,13 @@
 Rails.application.config.to_prepare do
   Permalink.on_generate do |object,target|
     if object.is_a? MediaObject
+      if object.is_streaming_reserve?
+        # objects in the Streaming Reserves unit should not receive handles
+        Rails.logger.debug("Skipping handle creation for #{object.id} in the '#{object.collection.unit}' unit because it is a streaming reserve item.")
+        return nil
+      end
+
+      Rails.logger.debug("Getting handle for #{object.id} in the '#{object.collection.unit}' unit.")
       handle = nil
       if object.other_identifier.present?
         hdl_id = object.other_identifier.find { |id| id[:source] == "handle" }


### PR DESCRIPTION
- Added an `is_streaming_reserve?` method to the MediaObject class
- Uses the streaming_reserves.unit_name setting introduced in LIBAVALON-388 to determine whether an object is a streaming reserve item
- Only get a handle if the object is not a streaming reserve item

https://umd-dit.atlassian.net/browse/LIBAVALON-377