### PR TITLE
LIBAVALON-405. Update Docker image tags for Avalon v7.8.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ networks:
 services:
   db: &db-avalon
     # UMD Customization
-    image: docker.lib.umd.edu/db:fedora4-avalon-7.7.2
+    image: docker.lib.umd.edu/db:fedora4-avalon-7.8.0
     # End UMD Customization
     volumes:
       - database:/data
@@ -37,7 +37,7 @@ services:
 
   fedora: &fedora
     # UMD Customization
-    image: docker.lib.umd.edu/fedora:4.7.5-avalon-7.7.2
+    image: docker.lib.umd.edu/fedora:4.7.5-avalon-7.8.0
     # End UMD Customization
     depends_on:
       - db
@@ -57,7 +57,7 @@ services:
 
   solr: &solr
     # UMD Customization
-    image: docker.lib.umd.edu/solr:avalon-7.7.2
+    image: docker.lib.umd.edu/solr:avalon-7.8.0
     # End UMD Customization
     volumes:
       - ./solr/conf:/opt/solr/avalon_conf
@@ -75,7 +75,7 @@ services:
 
   hls:
     # UMD Customization
-    image: docker.lib.umd.edu/nginx:avalon-7.7.2-umd-0
+    image: docker.lib.umd.edu/nginx:avalon-7.8.0-umd-0
     platform: linux/amd64
     # End UMD Customization
     environment:
@@ -93,7 +93,7 @@ services:
 
   redis: &redis
     # UMD Customization
-    image: docker.lib.umd.edu/redis:avalon-7.7.2
+    image: docker.lib.umd.edu/redis:avalon-7.8.0
     # End UMD Customization
     networks:
       internal:
@@ -102,7 +102,7 @@ services:
 
   avalon: &avalon
     # UMD Customization
-    image: docker.lib.umd.edu/avalon:7.7.2-umd-0
+    image: docker.lib.umd.edu/avalon:7.8.0-umd-0
     # End UMD Customization
     build:
       context: .


### PR DESCRIPTION
Updated Docker image tags for v7.8.0 (from v7.7.2), using the naming convention outlined in

https://github.com/umd-lib/avalon-docker/blob/release/7.8/UMD-README.md

https://umd-dit.atlassian.net/browse/LIBAVALON-405