### PR TITLE
LIBAVALON-386: Add Button to Generate CSV for External Groups

### DIFF
--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2024, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -232,7 +232,11 @@ class Admin::Collection < ActiveFedora::Base
     self.default_read_groups.select {|g| IPAddr.new(g) rescue false }
   end
 
-  # UMD Customization
+   # UMD Customization
+  def is_content_reserves?
+    self.name == 'Digitized Items'
+  end
+
   def default_umd_ip_manager_read_groups
     self.default_read_groups.select {|g| UmdIpManager::Group.valid_prefixed_key?(g) }
   end

--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -86,7 +86,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <div class="well-vertical-spacer">
     <%= link_to('Create An Item', new_media_object_path(collection_id: @collection.id), class: 'btn btn-primary') if can? :create, MediaObject %>
     <%= link_to('List All Items', search_catalog_path('f[collection_ssim][]' => @collection.name), class: 'btn btn-outline') %>
-    <% if @collection.name == 'Digitized Items' %>
+    <% if @collection.is_content_reserves? %>
       <%= link_to('Export Items with External Groups', external_groups_admin_collection_path(@collection, format: 'csv'), class: 'btn btn-outline') %>
     <% end %>
     <%= button_tag('Edit Collection Info', class: 'btn btn-outline', data: {toggle:"modal", target:"#new_collection"}) if can? :update, @collection %>

--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -86,6 +86,9 @@ Unless required by applicable law or agreed to in writing, software distributed
   <div class="well-vertical-spacer">
     <%= link_to('Create An Item', new_media_object_path(collection_id: @collection.id), class: 'btn btn-primary') if can? :create, MediaObject %>
     <%= link_to('List All Items', search_catalog_path('f[collection_ssim][]' => @collection.name), class: 'btn btn-outline') %>
+    <% if @collection.name == 'Digitized Items' %>
+      <%= link_to('Export Items with External Groups', external_groups_admin_collection_path(@collection, format: 'csv'), class: 'btn btn-outline') %>
+    <% end %>
     <%= button_tag('Edit Collection Info', class: 'btn btn-outline', data: {toggle:"modal", target:"#new_collection"}) if can? :update, @collection %>
   </div>
   <div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,7 @@ Rails.application.routes.draw do
         get 'remove'
         get 'items'
         get 'poster'
+        get 'external_groups'
         post 'poster', action: :attach_poster, as: 'attach_poster'
         delete 'poster', action: :remove_poster, as: 'remove_poster'
       end


### PR DESCRIPTION
This feature is only intended for Course Reserves

This adds a button to the manage content page of the Digitized Items page, which generates a CSV containing the items with external groups

https://umd-dit.atlassian.net/browse/LIBAVALON-386