### PR TITLE
LIBAVALON-401. Restore "Access Token" panel to "Access Control" page

### DIFF
--- a/app/javascript/components/MediaObjectRamp.jsx
+++ b/app/javascript/components/MediaObjectRamp.jsx
@@ -71,8 +71,20 @@ const Ramp = ({
 
   React.useEffect(() => {
     const { base_url, fullpath_url } = urls;
+    // UMD Customization
+    // Access tokens are included in the URL passed to this method,
+    // so need to modify the stock Avalon code to extract the "t"
+    // parameter (if present) using a more sophisticated method than the
+    // stock Avalon string regex.
+
     // Split the current path from the time fragment in the format .../:id?t=time
-    let [fullpath, start_time] = fullpath_url.split('?t=');
+    let url_to_parse = new URL(base_url+fullpath_url)
+    let url_params = url_to_parse.searchParams
+
+    let fullpath = url_to_parse.pathname;
+    let start_time = url_params.get("t") || undefined;
+    // End UMD Customization
+
     // Split the current path in the format /media_objects/:mo_id/section/:mf_id
     let [_, __, mo_id, ___, start_canvas] = fullpath.split('/');
     // Build the manifest URL

--- a/app/views/media_objects/_access_control.html.erb
+++ b/app/views/media_objects/_access_control.html.erb
@@ -89,6 +89,49 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 <% end %>
 
+<%# UMD Customization %>
+<div class="card access-token">
+  <div class="card-header">
+    <h3 class="card-title">Access Token</h3>
+  </div>
+  <div class="card-body">
+    <% if !@active_access_tokens.nil? && @active_access_tokens.any? %>
+      <div class="panel panel-default">
+        <h4>Active tokens</h4>
+        <table class="table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Token</th>
+              <th>Streaming?</th>
+              <th>Download?</th>
+              <th>Expires</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @active_access_tokens.each do |token| %>
+              <tr class="<%= css_classes(token) %>">
+                <td><%= link_to token.id, token %></td>
+                <td><%= link_to token.token, token %></td>
+                <td><% if token.allow_streaming %>Yes<% end %></td>
+                <td><% if token.allow_download %>Yes<% end %></td>
+                <td><%= token.expiration %><br>(<%= approximate_time_distance(token) %>)</td>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    <% end %>
+
+    <% unless @media_object.nil? || @media_object.id.nil? %>
+      <%= link_to new_access_token_path( {media_object_id: @media_object.id} ), class: 'btn btn-success' do %>
+        <i class="fa fa-plus"></i> Create a new token
+      <% end %>
+    <% end %>
+  </div>
+</div>
+<%# End UMD Customization %>
+
 <%= render 'modules/special_access', { object: @media_object } %>
 
 <%= render 'workflow_buttons', form: 'access_control_form' %>


### PR DESCRIPTION
Restored the UMD custom "Access Token" panel to the "Edit Media Object > Access Control" for media objects.

This is largely the same code as was in the
"app/views/modules/_access_control.html.erb" file which was deleted in Avalon 7.7.

The only real change was switching to using "card" instead of "panel" CSS styling for the outer panel, to match the styling of the other Avalon panels on the page.

https://umd-dit.atlassian.net/browse/LIBAVALON-401