### PR TITLE
LIBAVALON-418. Supplemental files not displayed for access tokens

### DIFF
--- a/app/views/media_objects/_item_view.html.erb
+++ b/app/views/media_objects/_item_view.html.erb
@@ -49,7 +49,12 @@ Unless required by applicable law or agreed to in writing, software distributed
         timeline: { canCreate: (current_ability.can? :create, Timeline), content: lending_enabled?(@media_object) ? (render('timeline') if can_stream) : render('timeline') },
         playlist: { canCreate: (current_ability.can? :create, Playlist), tab: render('add_to_playlist') },
         cdl: { enabled: lending_enabled?(@media_object), can_stream: can_stream, embed: render('embed_checkout'), destroy: render('destroy_checkout') },
-        has_files: @media_object.supplemental_files.present? || @media_object.sections_with_files.present?,
+        # UMD Customization
+        # Limit display of supplemental files in the "Files" tab to users
+        # who can actually download them (this excludes users with only a
+        # "download" access token)
+        has_files: (@media_object.supplemental_files.present? || @media_object.sections_with_files.present?) && (current_ability.can? :full_read, @media_object),
+        # End UMD Customization
         has_transcripts: @media_object.sections_with_files(tag: 'transcript').present?,
         # UMD Customization
         aeon_request: { 


### PR DESCRIPTION
Modified the flag used to display supplemental files in the "Files" tab to only show the supplemental files when the user has permission to actually download the files.

This excludes users who only have a UMD custom "download" access token.

https://umd-dit.atlassian.net/browse/LIBAVALON-418