### PR TITLE
LIBAVALON-402. Re-implement UMD IP Manager Special Access for Avalon 7.8

### DIFF
--- a/app/views/modules/_special_access.html.erb
+++ b/app/views/modules/_special_access.html.erb
@@ -36,6 +36,23 @@ Unless required by applicable law or agreed to in writing, software distributed
     <%= render "modules/access_object", object: object,
           access_object: "ipaddress", members: @ip_groups, leases: @ip_leases,
           input_disabled: !can_update %>
+    <%# UMD Customization %>
+    <% if @umd_ip_manager_error.nil? %>
+      <%= render "modules/access_object", object: object,
+            access_object: "umd_ip_manager_group", members: @umd_ip_manager_groups, leases: @umd_ip_manager_leases,
+            dropdown_values: [@addable_umd_ip_manager_groups, 'prefixed_key', 'name'],
+            display_helper: :umd_ip_manager_group_display,
+            access_object_remove_helper: :umd_ip_manager_group_access_object_remove_helper,
+            input_disabled: !can_update %>
+    <% else %>
+      <% access_object = "umd_ip_manager_group" %>
+      <div class="access-block col-lg-10" id="<%= access_object %>_management">
+       <%= bootstrap_form_for object do |form| %>
+         <%= render partial: "modules/tooltip", locals: { form: form, field: access_object, tooltip: t("access_control.#{access_object}"), options: {display_label: (t("access_control.#{access_object}label")+'*').html_safe} } %><br />
+         <div class="alert alert-danger"><%= @umd_ip_manager_error %></div>
+        <% end %>
+    <% end %>
+    <%# End UMD Customization %>
     <% if object.is_a?(Admin::Collection) %>
     <%= bootstrap_form_for object, html: { id: 'special_access_form' }  do |vid| %>
     <%= hidden_field_tag :save_field, 'special_access' %>


### PR DESCRIPTION
Restored the UMD IP Manager form in the "Access Control" step of the media object edit page, to re-implement the UMD IP Manager special access functionality originally implemented in LIBAVALON-264.

This code was taken unchanged from the
“app/views/modules/_access_control.html.erb” file in Avalon 7.4.

https://umd-dit.atlassian.net/browse/LIBAVALON-402