### PR TITLE
LIBAVALON-419: Avalon for Course Reserves

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,9 +103,18 @@ class ApplicationController < ActionController::Base
     # callback URL goes to 'section/:content'
     # and we want to redirect to '/master_files/%{content}/embed'
     # reference the media object route in routes.rb
-    if params['target_id'] && ((fetch_object(params['target_id'])).is_a? MasterFile)
-      logger.debug "Getting embed URL for master file"
-      "/master_files/" + params['target_id'] + "/embed"
+    if params['target_id'] == 'course_reserves'
+
+      if params['context_id'] == nil
+        logger.warn "No form data found, params['context_id'] is nil"
+        notice_text = "LTI Redirect URL failed"
+        redirect_to root_path, flash: { error: notice_text.html_safe }
+      end
+
+      logger.debug "Redirecting to Course Reserve Page for #{params['context_id']}"
+      collection = Admin::Collection.all.find { |collection| collection&.unit == Settings.streaming_reserves.unit_name }
+
+      "/collections/#{collection.id}/course_reserves?course_id=#{params['context_id']}"
     else
       logger.debug "Getting regular LTI Redirect URL"
       find_redirect_url(auth_type, lti_group: lti_group)

--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -234,7 +234,7 @@ class Admin::Collection < ActiveFedora::Base
 
    # UMD Customization
   def is_content_reserves?
-    self.name == 'Digitized Items'
+    self.unit == Settings.streaming_reserves.unit_name
   end
 
   def default_umd_ip_manager_read_groups

--- a/app/presenters/collection_presenter.rb
+++ b/app/presenters/collection_presenter.rb
@@ -1,11 +1,11 @@
 # Copyright 2011-2024, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
-# 
+#
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software distributed
 #   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 #   CONDITIONS OF ANY KIND, either express or implied. See the License for the
@@ -65,5 +65,9 @@ class CollectionPresenter
       poster_url: poster_url,
       url: collection_url
     }
+  end
+
+  def is_content_reserves?
+    self.unit == Settings.streaming_reserves.unit_name
   end
 end

--- a/app/views/collections/course_reserves.html.erb
+++ b/app/views/collections/course_reserves.html.erb
@@ -9,9 +9,7 @@
       <div class="list-group-item list-group-item-action">
         <h2> <%= link_to media_object.title, "/master_files/" + media_object.master_files.first.id + "/embed" %> </h2>
 
-        <%= link_to
-              image_tag("/master_files/" + media_object.master_files.first.id + "/thumbnail",
-                        class: 'result-thumbnail block'),
+        <%= link_to image_tag("/master_files/" + media_object.master_files.first.id + "/thumbnail", class: 'result-thumbnail block'),
               "/master_files/" + media_object.master_files.first.id + "/embed" %>
 
         <ul style="list-style: none; padding: 0; margin: 0;">

--- a/app/views/collections/course_reserves.html.erb
+++ b/app/views/collections/course_reserves.html.erb
@@ -1,0 +1,35 @@
+
+
+<div class="card">
+  <div class="card-header">
+    <h1 class="page-title">Avalon Streaming Reserves </h1>
+  </div>
+  <div class="card-body">
+    <% for media_object, solr_doc in @media_and_metadata %>
+      <div class="list-group-item list-group-item-action">
+        <h2> <%= link_to media_object.title, "/master_files/" + media_object.master_files.first.id + "/embed" %> </h2>
+
+        <%= link_to
+              image_tag("/master_files/" + media_object.master_files.first.id + "/thumbnail",
+                        class: 'result-thumbnail block'),
+              "/master_files/" + media_object.master_files.first.id + "/embed" %>
+
+        <ul style="list-style: none; padding: 0; margin: 0;">
+          <% (solr_doc['creator_ssim'] || []).each do |creator| %>
+            <li><%= creator %></li>
+          <% end %>
+
+          <% (solr_doc['contributor_ssim'] || []).each do |contributor| %>
+            <li><%= contributor %></li>
+          <% end %>
+
+          <li><%= solr_doc['terms_of_use_ssi'] %></li>
+
+          <% rights_url = solr_doc['rights_statement_ssi'] || '' %>
+          <li> <%= Avalon::ControlledVocabulary.find_by_name(:rights_statements)[rights_url] %> </li>
+        </ul>
+      </div>
+    <% end %>
+  </div>
+</div>
+

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -41,7 +41,10 @@ Unless required by applicable law or agreed to in writing, software distributed
       <div>
         <h3 class="sub-headline"><strong>Unit:</strong> <%= @doc_presenter.unit %></h3>
         <p class="lead document-description"></p>
-        <%= react_component("CollectionDetails", 
+        <% if @doc_presenter.is_content_reserves? %>
+          <%= link_to 'Show Course Reserves', course_reserves_collection_path(@doc_presenter.id), class: 'btn btn-primary' %>
+        <% end %>
+        <%= react_component("CollectionDetails",
           { content: @doc_presenter.description,
             email: @doc_presenter.contact_email,
             website: @doc_presenter.website_link

--- a/app/views/layouts/avalon.html.erb
+++ b/app/views/layouts/avalon.html.erb
@@ -59,7 +59,9 @@ Unless required by applicable law or agreed to in writing, software distributed
       <%= render partial: 'modules/become_message' %>
       <% end %>
       <%= render 'modules/header' %>
-      <%= render :partial => 'modules/global_navigation' %>
+      <% if controller.action_name != "course_reserves" %>
+        <%= render :partial => 'modules/global_navigation' %>
+      <% end %>
       <%# UMD Customization %>
       <% main_id = "content" unless ['catalog', 'bookmarks'].include?(controller.controller_name) %>
       <% main_id = "content" if current_page?(main_app.root_path) %>
@@ -82,7 +84,9 @@ Unless required by applicable law or agreed to in writing, software distributed
 
       </main>
     </div>
-    <%= render 'modules/footer' %>
+    <% if controller.action_name != "course_reserves" %>
+      <%= render 'modules/footer' %>
+    <% end %>
   </div>
 
   <% if request.fullpath.include?('login_popup') %>

--- a/app/views/modules/_header.html.erb
+++ b/app/views/modules/_header.html.erb
@@ -22,10 +22,10 @@ Unless required by applicable law or agreed to in writing, software distributed
         <%# End UMD Customization %>
       </div>
 
-      <% unless current_page?(main_app.root_path) %>
-      <div class="header-search">
-        <%= render :partial=>'modules/avalon_search_form' %>
-      </div>
+      <% if !current_page?(main_app.root_path) && controller.action_name != "course_reserves" %>
+        <div class="header-search">
+          <%= render :partial=>'modules/avalon_search_form' %>
+        </div>
       <% end %>
 
       <%# By default shift log in / log out to the header %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,7 @@ Rails.application.routes.draw do
   resources :collections, only: [:index, :show] do
     member do
       get :poster
+      get :course_reserves
     end
   end
 
@@ -167,7 +168,7 @@ Rails.application.routes.draw do
       post 'move'
       get 'transcript/:t_id', to: 'master_files#transcript'
       get :search
-      
+
       if Settings.derivative.allow_download
         get :download_derivative
       end


### PR DESCRIPTION
- Adds an endpoint to the collection controller for course reserves
- Uses form data from canvas to filter the collection per course
- Links to the embed endpoint for each Video/Audio recording
- Removes the Avalon header and footer when accessing the page

https://umd-dit.atlassian.net/browse/LIBAVALON-419