### PR TITLE
LIBAVALON-424. Suppress "View in Repository" button for LTI users.

### DIFF
--- a/app/javascript/components/embeds/EmbeddedRamp.jsx
+++ b/app/javascript/components/embeds/EmbeddedRamp.jsx
@@ -26,7 +26,10 @@ import './Ramp.scss';
 const Ramp = ({
 	urls,
 	media_object_id,
-  is_video
+  is_video,
+  // UMD Customization
+  allow_view_in_repo
+  // End UMD Customization
 }) => {
 	const [manifestUrl, setManifestUrl] = React.useState('');
 	const [startCanvasId, setStartCanvasId] = React.useState();
@@ -88,22 +91,23 @@ const Ramp = ({
         embeddedPlayer.controlBar.qualitySelector.dispose();
       }
 
-      // Create button component for "View in Repository" and add to control bar
-      let repositoryUrl = Object.values(urls).join('/').replace('/embed', '');
-      let position = embeddedPlayer.audioOnlyMode() ? embeddedPlayer.controlBar.children_.length : embeddedPlayer.controlBar.children_.length - 1;
-      var viewInRepoButton = embeddedPlayer.controlBar.addChild('button', {
-        clickHandler: function(event) {
-          window.open(repositoryUrl, '_blank').focus();
-        }
-      }, position);
+      if (allow_view_in_repo) {
+        // Create button component for "View in Repository" and add to control bar
+        let repositoryUrl = Object.values(urls).join('/').replace('/embed', '');
+        let position = embeddedPlayer.audioOnlyMode() ? embeddedPlayer.controlBar.children_.length : embeddedPlayer.controlBar.children_.length - 1;
+        var viewInRepoButton = embeddedPlayer.controlBar.addChild('button', {
+          clickHandler: function(event) {
+            window.open(repositoryUrl, '_blank').focus();
+          }
+        }, position);
 
-      viewInRepoButton.addClass('vjs-custom-external-link');
-      viewInRepoButton.el_.setAttribute('style', 'cursor: pointer;');
-      viewInRepoButton.controlText('View in Repository');
+        viewInRepoButton.addClass('vjs-custom-external-link');
+        viewInRepoButton.el_.setAttribute('style', 'cursor: pointer;');
+        viewInRepoButton.controlText('View in Repository');
 
-      // Add button icon
-      document.querySelector('.vjs-custom-external-link').innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512"><!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><style>svg{fill:#ffffff}</style><path d="M320 0c-17.7 0-32 14.3-32 32s14.3 32 32 32h82.7L201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L448 109.3V192c0 17.7 14.3 32 32 32s32-14.3 32-32V32c0-17.7-14.3-32-32-32H320zM80 32C35.8 32 0 67.8 0 112V432c0 44.2 35.8 80 80 80H400c44.2 0 80-35.8 80-80V320c0-17.7-14.3-32-32-32s-32 14.3-32 32V432c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16H192c17.7 0 32-14.3 32-32s-14.3-32-32-32H80z"/></svg>'
-
+        // Add button icon
+        document.querySelector('.vjs-custom-external-link').innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512"><!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><style>svg{fill:#ffffff}</style><path d="M320 0c-17.7 0-32 14.3-32 32s14.3 32 32 32h82.7L201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L448 109.3V192c0 17.7 14.3 32 32 32s32-14.3 32-32V32c0-17.7-14.3-32-32-32H320zM80 32C35.8 32 0 67.8 0 112V432c0 44.2 35.8 80 80 80H400c44.2 0 80-35.8 80-80V320c0-17.7-14.3-32-32-32s-32 14.3-32 32V432c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16H192c17.7 0 32-14.3 32-32s-14.3-32-32-32H80z"/></svg>'
+      }
       // This function only needs to run once, so we clear the interval here
       clearInterval(interval);
     }  

--- a/app/views/master_files/_player.html.erb
+++ b/app/views/master_files/_player.html.erb
@@ -18,6 +18,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   {
     urls: { base_url: request.protocol+request.host_with_port, fullpath_url: request.fullpath },
     media_object_id: @master_file.media_object_id,
-    is_video: @master_file.is_video?
+    is_video: @master_file.is_video?,
+    allow_view_in_repo: user_session[:full_login]
   }
 ) %>


### PR DESCRIPTION
- added an `allow_view_in_repo` parameter to the EmbeddedRamp React component
- in the master files player, use the `user_session[:full_login]` flag to as the value of `allow_view_in_repo`; this prevents LTI sessions (which have `:full_login` set to false) from displaying the "View in Repository" button, while retaining it in other cases

https://umd-dit.atlassian.net/browse/LIBAVALON-424