### PR TITLE
LIBAVALON-426. Backport right statement facet fix from upstream.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -88,7 +88,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'collection_ssim', label: 'Collection', limit: 5
     config.add_facet_field 'unit_ssim', label: 'Unit', limit: 5
     config.add_facet_field 'language_ssim', label: 'Language', limit: 5
-    config.add_facet_field 'rights_statement_ssi', label: 'Rights Statement', limit: 5, helper_method: :rights_statement_facet_display
+    config.add_facet_field 'rights_statement_ssi', label: 'Rights Statement', limit: 5, helper_method: :rights_statement_facet_display, solr_params: { "facet.contains" => "http"}
 
     # Hide these facets if not a Collection Manager
     # UMD Customization


### PR DESCRIPTION
Restrict rights statement facet to only http values which gets rid of blank values

https://umd-dit.atlassian.net/browse/LIBAVALON-426