### PR TITLE
LIBAVALON-426. Fix failing Avalon 7.8-umd-0 tests

### DIFF
--- a/app/controllers/master_files_controller.rb
+++ b/app/controllers/master_files_controller.rb
@@ -298,10 +298,12 @@ class MasterFilesController < ApplicationController
       # if streaming is allowed.
       cannot_stream = true
 
-      access_token = Rack::Utils.parse_nested_query(URI(request.referer).query)["access_token"]
-      if access_token.present?
-        media_object_id = @master_file.media_object.id
-        cannot_stream = !AccessToken.allow_streaming_of?(access_token, media_object_id)
+      unless request.referer.nil?
+        access_token = Rack::Utils.parse_nested_query(URI(request.referer).query)["access_token"]
+        if access_token.present?
+          media_object_id = @master_file.media_object.id
+          cannot_stream = !AccessToken.allow_streaming_of?(access_token, media_object_id)
+        end
       end
 
       return head :unauthorized if cannot?(:read, @master_file) && cannot_stream

--- a/app/views/master_files/_player.html.erb
+++ b/app/views/master_files/_player.html.erb
@@ -19,6 +19,6 @@ Unless required by applicable law or agreed to in writing, software distributed
     urls: { base_url: request.protocol+request.host_with_port, fullpath_url: request.fullpath },
     media_object_id: @master_file.media_object_id,
     is_video: @master_file.is_video?,
-    allow_view_in_repo: user_session[:full_login]
+    allow_view_in_repo: (user_session.nil? || user_session[:full_login])
   }
 ) %>

--- a/spec/controllers/access_tokens_controller_spec.rb
+++ b/spec/controllers/access_tokens_controller_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe AccessTokensController, type: :controller do
 
     it 'when an access token is successfully created, goes to the "show" page for that token' do
       login_as(:administrator)
-      media_object = FactoryBot.create(:media_object)
+      media_object = FactoryBot.create(:published_media_object)
       user = FactoryBot.create(:administrator)
 
       params = { access_token: { media_object_id: media_object.id, expiration: 7.days.from_now, user: user.username,

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -1259,17 +1259,6 @@ describe MediaObjectsController, type: :controller do
         get :show, params: { id: media_object.id, access_token: access_token.token }
         expect(controller.instance_variable_get('@playback_restricted')).to be false
       end
-
-      it 'should not be permitted for public but unpublished objects, even with an access token' do
-        media_object = FactoryBot.create(:media_object, visibility: 'public')
-        assert !media_object.published?
-        user = User.where(username: media_object.collection.managers.first).first
-        access_token = FactoryBot.create(:access_token, :allow_streaming, media_object_id: media_object.id, user: user)
-        access_token.save!
-
-        get :show, params: { id: media_object.id, access_token: access_token.token }
-        expect(controller.instance_variable_get('@playback_restricted')).to be true
-      end
     end
     # End UMD Customization
 

--- a/spec/controllers/media_objects_controller_spec.rb
+++ b/spec/controllers/media_objects_controller_spec.rb
@@ -678,7 +678,7 @@ describe MediaObjectsController, type: :controller do
 
     # UMD Customization
     it "should display active Access Tokens" do
-      media_object = FactoryBot.create(:media_object)
+      media_object = FactoryBot.create(:published_media_object)
       user = login_user media_object.collection.managers.first
 
       # When no access tokens, count should be zero

--- a/spec/factories/access_token.rb
+++ b/spec/factories/access_token.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :access_token do
     # Have an admin user by default, so token will be valid for any media object
     association :user, factory: :admin
-    media_object_id { FactoryBot.create(:media_object).id }
+    media_object_id { FactoryBot.create(:published_media_object).id }
     expiration { 7.days.from_now }
 
     trait :allow_streaming do

--- a/spec/jobs/cleanup_access_token_job_spec.rb
+++ b/spec/jobs/cleanup_access_token_job_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe CleanupAccessTokenJob do
   before do
-    @media_object = FactoryBot.create(:media_object)
+    @media_object = FactoryBot.create(:published_media_object)
     @unexpired_access_token = FactoryBot.create(:access_token, media_object_id: @media_object.id)
     @expiring_access_token = FactoryBot.create(:access_token, expiration: 30.minutes.from_now, media_object_id: @media_object.id)
     # Access tokens cannot be created as expired, so first create a token, and then set the expiration

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -195,17 +195,6 @@ describe Ability, type: :model do
           expect(ability).to_not be_able_to(:stream, unpublished_media_object)
         end
       end
-
-      it 'is not streamable even if an active access token allowing streaming is provided' do
-        # Access token does not allow streaming because media object is unpublished
-        access_token = FactoryBot.create(:access_token, :allow_streaming)
-        access_token.media_object_id = unpublished_media_object.id
-        access_token.save!
-
-        token = access_token.token
-        ability = Ability.new(nil, { access_token: token })
-        expect(ability).to_not be_able_to(:stream, unpublished_media_object)
-      end
     end
 
     context 'when media object is published' do

--- a/spec/models/access_token_spec.rb
+++ b/spec/models/access_token_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe AccessToken, type: :model do
     end
   end
 
-  context 'is valid when given an existing media object, an expiration in the future, and' do
+  context 'is valid when given an existing published media object, an expiration in the future, and' do
     it 'an admin user' do
       admin_user = FactoryBot.create(:admin)
       access_token = FactoryBot.create(:access_token, user: admin_user)
@@ -37,7 +37,7 @@ RSpec.describe AccessToken, type: :model do
     it 'a manager of the collection' do
       manager = FactoryBot.create(:manager)
       collection = FactoryBot.create(:collection, :with_manager, manager: manager)
-      media_object = FactoryBot.create(:media_object, collection: collection)
+      media_object = FactoryBot.create(:published_media_object, collection: collection)
       access_token = FactoryBot.create(:access_token, media_object_id: media_object.id, user: manager)
 
       expect(access_token.valid?).to be true
@@ -46,7 +46,7 @@ RSpec.describe AccessToken, type: :model do
     it 'an editor of the collection' do
       editor = FactoryBot.create(:user) # Any user can be an editor
       collection = FactoryBot.create(:collection, :with_editor, editor: editor)
-      media_object = FactoryBot.create(:media_object, collection: collection)
+      media_object = FactoryBot.create(:published_media_object, collection: collection)
       access_token = FactoryBot.create(:access_token, media_object_id: media_object.id, user: editor)
 
       expect(access_token.valid?).to be true
@@ -55,7 +55,7 @@ RSpec.describe AccessToken, type: :model do
     it 'a depositor of the collection' do
       depositor = FactoryBot.create(:user) # Any user can be a depositor
       collection = FactoryBot.create(:collection, :with_depositor, depositor: depositor)
-      media_object = FactoryBot.create(:media_object, collection: collection)
+      media_object = FactoryBot.create(:published_media_object, collection: collection)
       access_token = FactoryBot.create(:access_token, media_object_id: media_object.id, user: depositor)
 
       expect(access_token.valid?).to be true


### PR DESCRIPTION
## Modified access token tests to use a published media object

In LIBAVALON-388/LIBAVALON-406 the AccessToken model was changed to validate that the media object associated with the access token is published.

This change caused some access token tests to fail because the media object created for the test was not published. Modified these tests to use a published media object.

## Removed tests verifying access token behavior for unpublished items

Two tests were verifying that unpublished media objects could not be streamed, even with an active media token. These tests were failing because the access token could not be created, due to the AccessToken model validation that the media object be published.

Given the changes to the AccessToken validation, keeping these tests did not seem useful, so that were deleted.

## Modified “_player.html.erb” partial to make “user_session” optional

In the “app/views/master_files/_player.html.erb” partial, the “user_session” variable used in determining the “allow_view_in_repo” parameter (added in LIBAVALON-424) is not always set by tests, causing them to fail.

The “allow_view_in_repo” is designed to be “false” only for LTI callbacks (which have a “user_session” with a “full_login” value of “false”). Since it seemed reasonable that a “user_session” might not always exist, modified the partial to make the “user_session” optional (“allow_view_in_repo” will be true, if “user_session” is not set, preserving the existing behavior).

## Added nil check for “request.referer” to “hls_manifest” method in master_files_controller.rb

Modified the “hls_manifest” method in “app/controllers/master_files_controller.rb” to check whether the “request.referer” is nil before attempting to retrieve the “access_token” parameter.

Some tests were failing because the “request.referer” parameter was nil, and adding this check seemed like a reasonable fix to make.

https://umd-dit.atlassian.net/browse/LIBAVALON-436