### PR TITLE
LIBAVALON-440. Improve ExternalGroup input in access control.

### DIFF
--- a/app/models/access_control_step.rb
+++ b/app/models/access_control_step.rb
@@ -74,7 +74,14 @@ class AccessControlStep < Avalon::Workflow::BasicStep
                 context[:error] = e.message
               end
             else
-              media_object.read_groups += [val]
+              # UMD Customization
+              # Validate 'val' to ensure a Course with the given context_id exists
+              if title == 'class' && Course.where(context_id: val).empty?
+                context[:error] = "Course '#{val}' does not exist."
+              else
+                media_object.read_groups += [val]
+              end
+              # End UMD Customization
             end
           end
         else

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -16,7 +16,9 @@ class Course < ActiveRecord::Base
 #  attr_accessible :context_id, :label, :title
 
   def self.autocomplete(query, _id = nil)
-    self.where("label LIKE :q OR title LIKE :q", q: "%#{query}%").collect { |course|
+    # UMD Customization
+    self.where("LOWER(label) LIKE :q OR LOWER(title) LIKE :q", q: "%#{query.downcase}%").collect { |course|
+    # End UMD Customization
       { id: course.context_id, display: course.title }
     }
   end


### PR DESCRIPTION
- [Make "External Group" auto-complete case-insensitive.](https://github.com/umd-lib/avalon/commit/70c4b4d4ba6d72d8a65507617f48d41e81643b71)
- [Add validation for External Group "course" in access-control step.](https://github.com/umd-lib/avalon/commit/443456c2fb7ea4c1c14ab0bf48e65b0708d1cf17)

https://umd-dit.atlassian.net/browse/LIBAVALON-440