### PR TITLE
LIBAVALON-374. Add S3 presigned URL header.

### DIFF
--- a/app/controllers/derivatives_controller.rb
+++ b/app/controllers/derivatives_controller.rb
@@ -27,6 +27,12 @@ class DerivativesController < ApplicationController
       return head :forbidden
     end
 
+    # If the request header contains 'S3-Presigned-URL', we need to generate a presigned URL
+    if request.headers['X-Want-S3-Presigned-URL'] == 'true'
+      presigned_url = presigned_streaming_url(bucket:  Settings.encoding.derivative_bucket, key: params[:name], expires_in: 300)
+      response.set_header('X-S3-Presigned-URL', presigned_url)
+    end
+
     respond_to do |format|
       format.urlencoded do
         resp[:authorized] = resp[:authorized].join(';')
@@ -45,4 +51,11 @@ class DerivativesController < ApplicationController
   rescue StreamToken::Unauthorized
     return head :forbidden
   end
+
+  private
+
+    def presigned_streaming_url(bucket:, key:, expires_in: 300)
+      object = Aws::S3::Object.new(bucket_name: bucket, key: key)
+      object.presigned_url(:get, expires_in: expires_in)
+    end
 end

--- a/app/helpers/upload_form_helper.rb
+++ b/app/helpers/upload_form_helper.rb
@@ -14,7 +14,9 @@
 
 module UploadFormHelper
   def direct_upload?
-    Settings.encoding.engine_adapter.to_sym == :elastic_transcoder || Settings.minio.present?
+    # UMD Customization
+    Settings.encoding.masterfile_bucket.present? || Settings.minio.present?
+    # END UMD Customization
   end
 
   def upload_form_classes

--- a/app/services/master_file_builder.rb
+++ b/app/services/master_file_builder.rb
@@ -38,34 +38,9 @@ module MasterFileBuilder
         raise BuildError, 'The file you have uploaded has invalid characters in its name.'
       end
 
-      # UMD Customization
-      # Start LIBAVALON-128, LIBAVALON-286
-      collection_path = media_object.collection.dropbox_absolute_path
-      original_filename = spec.content.respond_to?("original_filename") ? spec.content.original_filename : spec.original_filename;
-      desination_path = File.join(collection_path, 'uploads', DateTime.now.strftime("%Y%m%d"), DateTime.now.strftime("%H%M%S%L"), original_filename)
-      if (File.exist?(desination_path))
-        response[:flash][:error] << "Duplicate file. File already exists at path #{desination_path}!"
-        next
-      end
-      content = spec.content
-      FileUtils.mkdir_p(File.dirname(desination_path))
-      # if uploaded file, move from /tmp dir to collection dir in masterfiles volume.
-      if content.is_a? ActionDispatch::Http::UploadedFile
-        FileUtils.mv(content.path, desination_path)
-        content = Addressable::URI.join('file:///', desination_path)
-      # else, if Google drive file, copy to the local dropbox upload dir before processing -- the authorization
-      # header is not available to the post processing move task, and therefore, it is unable to move/copy the
-      # file from the google drive to the archive directory to make it available for downloads.
-      elsif content.to_s.starts_with?('https://www.googleapis.com')
-        IO.copy_stream(URI.open(content, spec.auth_header), desination_path)
-        content = Addressable::URI.join('file:///', desination_path)
-      end
-
       master_file = MasterFile.new()
-      master_file.setContent(content, file_name: spec.original_filename, file_size: spec.file_size, auth_header: nil, dropbox_dir: media_object.collection.dropbox_absolute_path)
+      master_file.setContent(spec.content, file_name: spec.original_filename, file_size: spec.file_size, auth_header: spec.auth_header, dropbox_dir: media_object.collection.dropbox_absolute_path)
       master_file.set_workflow(spec.workflow)
-      # End LIBAVALON-128, LIBAVALON-286
-      # End UMD Customization
 
       if 'Unknown' == master_file.file_format
         response[:flash][:error] << "The file was not recognized as audio or video - %s (%s)" % [spec.original_filename, spec.content_type]


### PR DESCRIPTION
Add the S3 Presigned URL for streaming from S3 in the `X-S3-Presigned-URL` response header, if Nginx authorize request includes `X-Want-S3-Presigned-URL` header.

https://umd-dit.atlassian.net/browse/LIBAVALON-374