### PR TITLE
LIBAVALON-456. Add courses controller and view.

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,0 +1,59 @@
+# Copyright 2011-2024, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+class CoursesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :auth, except: [:stop_impersonating]
+  before_action :auth_admin, only: [:impersonate]
+
+  def index
+    @courses = courses_list
+  end
+
+  # Become a user
+  def impersonate
+    course_context_id = params[:id]
+    user = User.find_by(email: course_context_id + '@' + ENV['SETTINGS__DOMAIN__HOST'])
+    impersonate_user(user)
+    user_session[:virtual_groups] = [course_context_id]
+    user_session[:full_login] = false
+    params['target_id'] = 'course_reserves'
+    params['context_id'] = course_context_id
+    redirect_to lti_redirect_url('lti', lti_group: course_context_id)
+  end
+
+  def stop_impersonating
+    stop_impersonating_user
+    user_session[:virtual_groups] = current_user.ldap_groups
+    user_session.delete(:full_login)
+    params.delete('target_id')
+    params.delete('context_id')
+    redirect_to courses_path, notice: t('samvera.persona.users.become.over')
+  end
+
+  private
+
+    def auth
+      authorize! :read, Course
+    end
+
+    def auth_admin
+      current_ability.is_administrator?
+    end
+
+    def courses_list
+      courses = Course.all.order(created_at: :desc)
+      courses.page(params[:page])
+    end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -157,6 +157,8 @@ class Ability
       can :list_all, AccessToken if is_administrator?
 
       can :manage, AccessToken if (is_member_of_any_collection? or @user_groups.include? 'manager')
+
+      can :read, Course if is_course_reserves_manager?
       # End UMD Customization
 
       cannot :read, [Admin::Collection, SpeedyAF::Proxy::Admin::Collection] unless (full_login? || is_api_request?)
@@ -368,6 +370,12 @@ class Ability
     end
 
     allowed
+  end
+
+  def is_course_reserves_manager?
+    course_reserves_collection = Admin::Collection.all.find { |collection| collection&.unit == Settings.streaming_reserves.unit_name }
+    Rails.logger.debug "Course Reserves Collection: #{course_reserves_collection.managers.inspect} for user #{@user.username}"
+    @user.in?(course_reserves_collection.managers)
   end
   # End UMD Customization
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -185,7 +185,7 @@ class User < ActiveRecord::Base
     
     # UMD Customization
     # Creating a dummy email based on the context_id and the streaming hostname (Canvas doesn't provide an email)
-    email = auth_hash.info.email || class_id + '@' + ENV['STREAMING_HOST']
+    email = auth_hash.info.email || class_id + '@' + ENV['SETTINGS__DOMAIN__HOST']
     # Using Avalon course name as the username to be more readable
     find_or_create_by_username_or_email(class_name, email, 'lti')
     # End UMD Customization

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -65,6 +65,10 @@ Unless required by applicable law or agreed to in writing, software distributed
           <li class="nav-item <%= active_for_controller('access_tokens') %>">
             <%= link_to 'Manage Access Tokens', main_app.access_tokens_path, class: 'nav-link' %></li>
           <% end %>
+          <% if can? :read, Course %>
+          <li class="nav-item <%= active_for_controller('courses') %>">
+            <%= link_to 'View Courses', main_app.courses_path, class: 'nav-link' %></li>
+          <% end %>
           <%# End UMD Customization %>
           <% if can? :read, Admin::Collection %>
           <li class="nav-item <%= active_for_controller('admin/collections') %>">

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -1,0 +1,60 @@
+<%#
+Copyright 2011-2024, The Trustees of Indiana University and Northwestern
+  University.  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+  under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+  CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations under the License.
+---  END LICENSE_HEADER BLOCK  ---
+%>
+
+<h1>Courses</h1>
+
+<div>
+  <%= paginate @courses %>
+</div>
+
+<table class="table">
+  <thead>
+  <tr>
+    <th>ID</th>
+    <th>Title</th>
+    <th>Created</th>
+    <th></th>
+    <th></th>
+  </tr>
+  </thead>
+  <tbody>
+  <% if @courses.length > 0 %>
+    <% @courses.each do |course| %>
+      <tr>
+        <td><%= course.id %></td>
+        <td><%= course.title %></td>
+        <td><%= course.created_at %></td>
+        <td>
+          <%= link_to 'Browse Course Items', search_catalog_path('f[course_title_ssim][]' => course.title), class: 'btn btn-outline' %>
+        </td>
+        <td>
+          <% if current_ability.is_administrator? %>
+            <%= link_to 'Impersonate as course user', impersonate_course_path(course.context_id), method: :post, class: 'btn btn-outline' %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  <% else %>
+  <tr>
+    <td colspan="9">No courses found</td>
+  </tr>
+  <% end %>
+  </tbody>
+</table>
+
+<div>
+  <%= paginate @courses %>
+</div>

--- a/app/views/modules/_become_message.html.erb
+++ b/app/views/modules/_become_message.html.erb
@@ -16,6 +16,12 @@ Unless required by applicable law or agreed to in writing, software distributed
 <% if defined?(true_user) && current_user != true_user %>
   <div class="alert alert-info log-in-out" style="margin-bottom: 0;">
     You (<%= true_user.email %>) are signed in as <%= current_user.email %>
-    <%= link_to "Back to admin", main_app.stop_impersonating_persona_users_path, method: :post %>
+    <%# UMD Customization %>
+    <% if user_session[:full_login] == false %>
+      <%= link_to "Back to orginal login", stop_impersonating_courses_path, method: :post %>
+    <% else %>
+      <%= link_to "Back to admin", main_app.stop_impersonating_persona_users_path, method: :post %>
+    <% end %>
+    <%# End UMD Customization %>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,7 +107,9 @@ Rails.application.routes.draw do
   resources :collections, only: [:index, :show] do
     member do
       get :poster
+      # UMD Customization
       get :course_reserves
+      # End UMD Customization
     end
   end
 
@@ -255,6 +257,17 @@ Rails.application.routes.draw do
 
   # UMD Customization
   resources :access_tokens
+  # End UMD Customization
+
+  # UMD Customization
+  resources :courses do
+    member do
+      post 'impersonate', to: 'courses#impersonate'
+    end
+    collection do
+      post 'stop_impersonating', to: 'courses#stop_impersonating'
+    end
+  end
   # End UMD Customization
 
   scope :persona, as: 'persona' do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,8 +118,8 @@ services:
       # UMD Customization
       - APP_NAME=avalon
       - SETTINGS__DOMAIN__PROTOCOL=http
-      - SETTINGS__DOMAIN_HOST=av-local
-      - SETTINGS__DOMAIN_PORT=3000
+      - SETTINGS__DOMAIN__HOST=av-local
+      - SETTINGS__DOMAIN__PORT=3000
       - BUNDLE_FLAGS=--with development postgres --without production test
       - ENCODE_WORK_DIR=/streamfiles
       - CONTROLLED_VOCABULARY=config/controlled_vocabulary.yml


### PR DESCRIPTION
- Add a courses index page to display all courses.
- Add a "View Courses" menu to the "Manage" menu.
- Add ability to check for course reserve manager.
- Add impersonation capability for admins to see course reserve landing page without needing canvas access.
- Use 'SETTINGS__DOMAIN__HOST' instead of 'STREAMING_HOST' to future proof in case the streaming host changes to AWS Cloudfront.
- Fix typo in docker compose env vars

https://umd-dit.atlassian.net/browse/LIBAVALON-456