### PR TITLE
LIBAVALON-459. Export all course reserves items.

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -309,10 +309,8 @@ class Admin::CollectionsController < ApplicationController
 
     logger.info "Fetching external groups for collection: #{@collection.name}"
     query = "collection_ssim:\"#{@collection.name}\""
-    response = ActiveFedora::SolrService.get(query)['response']['docs'] ||= []
+    items = ActiveFedora::SolrService.get(query)['response']['docs'] ||= []
     logger.info response
-
-    items = response.select { |item| item["read_access_virtual_group_ssim"] !=  nil }
 
     require 'csv'
 
@@ -320,7 +318,7 @@ class Admin::CollectionsController < ApplicationController
       csv << ["Item", "External Groups"]
 
       items.each do |item|
-        vgroup_display = item["read_access_virtual_group_ssim"].map { |id| Course.find_by_context_id(id).title }
+        vgroup_display = item["read_access_virtual_group_ssim"]&.map { |id| Course.find_by_context_id(id).title } || []
         csv << [item["title_tesi"], vgroup_display.join("|")]
       end
     end

--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -87,7 +87,7 @@ Unless required by applicable law or agreed to in writing, software distributed
     <%= link_to('Create An Item', new_media_object_path(collection_id: @collection.id), class: 'btn btn-primary') if can? :create, MediaObject %>
     <%= link_to('List All Items', search_catalog_path('f[collection_ssim][]' => @collection.name), class: 'btn btn-outline') %>
     <% if @collection.is_content_reserves? %>
-      <%= link_to('Export Items with External Groups', external_groups_admin_collection_path(@collection, format: 'csv'), class: 'btn btn-outline') %>
+      <%= link_to('Export Items', external_groups_admin_collection_path(@collection, format: 'csv'), class: 'btn btn-outline') %>
     <% end %>
     <%= button_tag('Edit Collection Info', class: 'btn btn-outline', data: {toggle:"modal", target:"#new_collection"}) if can? :update, @collection %>
   </div>


### PR DESCRIPTION
Previous implementation only exported items with associated course. With this refactor, all items in the course rererves collection are exported.

https://umd-dit.atlassian.net/browse/LIBAVALON-459