### PR TITLE
LIBAVALON-475. Set content_type for caption file.

### DIFF
--- a/lib/avalon/batch/entry.rb
+++ b/lib/avalon/batch/entry.rb
@@ -298,6 +298,10 @@ module Avalon
         # Create SupplementalFile
         supplemental_file = SupplementalFile.new(label: label, tags: [type, treat_as_transcript, machine_generated].uniq.compact, language: language, parent_id: parent_id)
         supplemental_file.file.attach(io: FileLocator.new(datastream[file_key]).reader, filename: filename)
+        # UMD Customization (This can be removed after v8.1.1 upgrade)
+        extension = File.extname(datastream[file_key])
+        supplemental_file.file.content_type = Mime::Type.lookup_by_extension(extension.slice(1..-1)).to_s if extension == '.srt'
+        # End UMD Customization
         supplemental_file.save ? supplemental_file : nil
       end
       private_class_method :process_datastream


### PR DESCRIPTION
Copy the logic from web workflow so that content_type gets set during batch loading. Without this, the SupplementalFile validation fails for Captions. This has been addressed in Avalon 8.1.1, but we cannot port that change since it also includes other changes.

https://umd-dit.atlassian.net/browse/LIBAVALON-475