### PR TITLE
LIBAVALON-478. Add DeleteOldSearchesJob cron job back.

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -23,6 +23,7 @@ Rails.application.config.to_prepare do
     Sidekiq::Cron::Job.create(name: 'Clean out user sessions older than 7 days - every 6hour', cron: '0 */6 * * *', class: 'CleanupSessionJob')
     # UMD Customization
     Sidekiq::Cron::Job.create(name: 'Clean up access tokens that have past their expiration date - every 1day', cron: '0 1 * * *', class: 'CleanupAccessTokenJob')
+    Sidekiq::Cron::Job.create(name: 'Delete old searches - every 20 minutes', cron: '0,20,40 * * * *', class: 'DeleteOldSearchesJob')
     # End UMD Customization
 rescue Redis::CannotConnectError => e
     Rails.logger.warn "Cannot create sidekiq-cron jobs: #{e.message}"


### PR DESCRIPTION
The job was originially failing due to 45Million+ records
that has accumulated over the years. We have manually
cleaned up the old searches, so we can enable this again.

Revert "LIBAVALON-478. Remove DeleteOldSearchesJob cron job;"

This reverts commit 3b2b4991518debe403262eaa11a8c6d3f6cf2af9.

https://umd-dit.atlassian.net/browse/LIBAVALON-478