### PR TITLE
LIBAVALON-479. Add cron job to cleanup encode files.

### DIFF
--- a/app/jobs/delete_old_encode_files_job.rb
+++ b/app/jobs/delete_old_encode_files_job.rb
@@ -1,0 +1,24 @@
+# Copyright 2011-2024, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+class DeleteOldEncodeFilesJob < ActiveJob::Base
+
+  def perform
+    options = {
+      older_than: 2.weeks,
+      all: true
+    }
+    ActiveEncode::EngineAdapters::FfmpegAdapter.remove_old_files!(options)
+  end
+
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -24,6 +24,7 @@ Rails.application.config.to_prepare do
     # UMD Customization
     Sidekiq::Cron::Job.create(name: 'Clean up access tokens that have past their expiration date - every 1day', cron: '0 1 * * *', class: 'CleanupAccessTokenJob')
     Sidekiq::Cron::Job.create(name: 'Delete old searches - every 20 minutes', cron: '0,20,40 * * * *', class: 'DeleteOldSearchesJob')
+    Sidekiq::Cron::Job.create(name: 'Delete old encode files - every 1day', cron: '0 1 * * *', class: 'DeleteOldEncodeFilesJob')
     # End UMD Customization
 rescue Redis::CannotConnectError => e
     Rails.logger.warn "Cannot create sidekiq-cron jobs: #{e.message}"

--- a/lib/tasks/avalon.rake
+++ b/lib/tasks/avalon.rake
@@ -54,8 +54,13 @@ namespace :avalon do
 
   desc 'clean out old ffmpeg and pass_through encode files'
   task local_encode_cleanup: :environment do
+    # UMD Customization
+    older_than_raw = ENV['older_than'] || "2.weeks"
+    older_than = parse_duration(older_than_raw)
+
     options = {
-      older_than: ENV['older_than'], # Default is 2.weeks
+      older_than: older_than, # Default is 2.weeks
+      # End UMD Customization
       no_outputs: ENV['no_outputs']&.to_a, # Default is ['input_metadata', 'duration_input_metadata', 'error.log', 'exit_status.code', 'progress', 'completed', 'pid', 'output_metadata-*']
       outputs: ENV['outputs'], # Default is false
       all: ENV['all'] # Default is false
@@ -63,6 +68,19 @@ namespace :avalon do
 
     ActiveEncode::EngineAdapters::FfmpegAdapter.remove_old_files!(options)
   end
+
+  # UMD Customization
+  def parse_duration(str)
+    unless str =~ /\A(\d+)\.(days?|weeks?|hours?|minutes?|seconds?)\z/
+      raise ArgumentError, "Invalid format: #{str.inspect}"
+    end
+
+    amount = $1.to_i
+    unit   = $2
+
+    amount.public_send(unit)
+  end
+  # End UMD Customization
 
   namespace :services do
     services = ["jetty", "felix", "delayed_job"]


### PR DESCRIPTION
Also, updated rake task to be able to parse older_than correctly for manual cleanup runs.

https://umd-dit.atlassian.net/browse/LIBAVALON-479