### PR TITLE
LIBAVALON-480. Distributed encode processing changes.

### DIFF
--- a/app/models/CustomPolling.rb
+++ b/app/models/CustomPolling.rb
@@ -1,0 +1,36 @@
+# Copyright 2011-2024, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
+# frozen_string_literal: true
+require 'active_support/core_ext/integer/time'
+require 'active_model/callbacks'
+
+module CustomPolling
+  extend ActiveSupport::Concern
+
+  CALLBACKS = [
+      :after_status_update, :after_failed, :after_cancelled, :after_completed
+  ].freeze
+
+  included do
+    extend ActiveModel::Callbacks
+
+    define_model_callbacks :status_update, :failed, :cancelled, :completed, only: :after
+
+    after_create do |encode|
+      # Noop
+    end
+  end
+end
+

--- a/app/models/watched_encode.rb
+++ b/app/models/watched_encode.rb
@@ -14,7 +14,9 @@
 
 class WatchedEncode < ActiveEncode::Base
   include ::ActiveEncode::Persistence
-  include ::ActiveEncode::Polling
+  # UMD Customization
+  include ::CustomPolling
+  # End UMD Customization
 
   around_create do |encode, block|
     master_file_id = encode.options[:master_file_id]

--- a/lib/tasks/umd.rake
+++ b/lib/tasks/umd.rake
@@ -30,6 +30,41 @@ namespace :umd do
       collection.ensure_collection_s3_bucket
     end
   end
+
+  desc "Process running encodes on distributed workers"
+  task process_running_encodes: :environment do
+    # Find encode records in 'running' state within the 24 hours
+    encodes = ActiveEncode::EncodeRecord.where(state: 'running').where('updated_at >= ?', 24.hours.ago)
+
+    # For each running encode, process it if the encode dir exists in the current worker
+    processed_encodes = encodes.filter_map do |encode_record|
+      global_id = encode_record.global_id
+      uuid = global_id.split('/').last
+      encode_dir = File.join(ENV['ENCODE_WORK_DIR'], uuid)
+      if Dir.exist?(encode_dir)
+        encode = FfmpegEncode.find(uuid)
+        process_encode(encode)
+        encode
+      end
+    end
+    Rails.logger.info("Processed #{processed_encodes.count} running encodes on this worker.")
+  end
+end
+
+def process_encode(encode)
+  encode.run_callbacks(:status_update) { encode }
+  case encode.state
+  when :failed
+    encode.run_callbacks(:failed) { encode }
+  when :cancelled
+    encode.run_callbacks(:cancelled) { encode }
+  when :completed
+    encode.run_callbacks(:completed) { encode }
+  when :running
+    # no-op
+  else # other states are illegal and ignored
+    raise StandardError, "Illegal state #{encode.state} in encode #{encode.id}!"
+  end
 end
 
 def move_dropbox_files_to_archive(archive_dir, dry_run=false)

--- a/script/worker_entrypoint.sh
+++ b/script/worker_entrypoint.sh
@@ -16,28 +16,32 @@
 
 #!/bin/bash
 
-SIDEKIQ_PID=""
-
-# Trap signals and forward them
-trap 'handle_tstp' USR1
-
-forward_signal() {
-  echo "Received SIGUSR1, forwarding to Sidekiq..." >&2
+forward_term() {
+  echo "Received SIGTERM, forwarding to Sidekiq..." >&2
   # Find the actual sidekiq process
-  SIDEKIQ_PID=$(pgrep -f "sidekiq.*config/sidekiq.yml")
+  SIDEKIQ_PID=$(pgrep -f "sidekiq")
   if [ -n "$SIDEKIQ_PID" ]; then
     echo "Forwarding to PID: $SIDEKIQ_PID" >&2
-    kill -USR1 "$SIDEKIQ_PID"
+    kill -TERM "$SIDEKIQ_PID"
   else
     echo "Sidekiq process not found" >&2
   fi
 }
 
-trap 'forward_signal' USR1
+# Trap TERM signal
+trap 'forward_term' TERM
 
 # Start periodic script
 /home/app/avalon/script/worker_rake_tasks.sh &
 
 # Start Sidekiq
 echo "Starting Sidekiq..."
-exec bundle exec sidekiq -t "${SIDEKIQ_TERMINATION_GRACE_PERIOD:-1800}" -C config/sidekiq.yml
+bundle exec sidekiq -t "${SIDEKIQ_TERMINATION_GRACE_PERIOD:-1800}" -C config/sidekiq.yml &
+
+# Wait for Sidekiq to exit
+wait $(pgrep -f "sidekiq")
+
+# Allow rake tasks to run one last time before exiting
+echo "Sidekiq exiting, waiting for rake tasks polling interval + 60 seconds to ensure progress update"
+sleep $(( ${POLLING_INTERVAL:-60} + 60 ))
+echo "Worker exiting."

--- a/script/worker_entrypoint.sh
+++ b/script/worker_entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+# Start periodic script
+/home/app/avalon/script/worker_rake_tasks.sh &
+
+# Start Sidekiq
+echo "Starting Sidekiq..."
+
+bundle exec sidekiq -t "${SIDEKIQ_TERMINATION_GRACE_PERIOD:-1800}" -C config/sidekiq.yml &
+
+# Wait for either process to exit
+wait -n
+
+# Exit with status of the first process that exits
+exit $?

--- a/script/worker_entrypoint.sh
+++ b/script/worker_entrypoint.sh
@@ -1,3 +1,19 @@
+#!/usr/bin/env bash
+
+# Copyright 2011-2023, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
 #!/bin/bash
 set -e
 

--- a/script/worker_entrypoint.sh
+++ b/script/worker_entrypoint.sh
@@ -15,18 +15,29 @@
 # ---  END LICENSE_HEADER BLOCK  ---
 
 #!/bin/bash
-set -e
+
+SIDEKIQ_PID=""
+
+# Trap signals and forward them
+trap 'handle_tstp' USR1
+
+forward_signal() {
+  echo "Received SIGUSR1, forwarding to Sidekiq..." >&2
+  # Find the actual sidekiq process
+  SIDEKIQ_PID=$(pgrep -f "sidekiq.*config/sidekiq.yml")
+  if [ -n "$SIDEKIQ_PID" ]; then
+    echo "Forwarding to PID: $SIDEKIQ_PID" >&2
+    kill -USR1 "$SIDEKIQ_PID"
+  else
+    echo "Sidekiq process not found" >&2
+  fi
+}
+
+trap 'forward_signal' USR1
 
 # Start periodic script
 /home/app/avalon/script/worker_rake_tasks.sh &
 
 # Start Sidekiq
 echo "Starting Sidekiq..."
-
-bundle exec sidekiq -t "${SIDEKIQ_TERMINATION_GRACE_PERIOD:-1800}" -C config/sidekiq.yml &
-
-# Wait for either process to exit
-wait -n
-
-# Exit with status of the first process that exits
-exit $?
+exec bundle exec sidekiq -t "${SIDEKIQ_TERMINATION_GRACE_PERIOD:-1800}" -C config/sidekiq.yml

--- a/script/worker_rake_tasks.sh
+++ b/script/worker_rake_tasks.sh
@@ -1,3 +1,19 @@
+#!/usr/bin/env bash
+
+# Copyright 2011-2023, The Trustees of Indiana University and Northwestern
+#   University.  Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+# 
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software distributed
+#   under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#   CONDITIONS OF ANY KIND, either express or implied. See the License for the
+#   specific language governing permissions and limitations under the License.
+# ---  END LICENSE_HEADER BLOCK  ---
+
 #!/bin/bash
 
 # Define ffpmeg cleanup parameters

--- a/script/worker_rake_tasks.sh
+++ b/script/worker_rake_tasks.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Define ffpmeg cleanup parameters
+export older_than="${older_than:-1.days}"
+export outputs="${older_than:-true}"
+
+export POLLING_INTERVAL="${POLLING_INTERVAL:-60}"
+
+while true; do
+  echo "[periodic] Running worker_rake_tasks script at $(date)"
+  cd /home/app/avalon || exit 2
+  echo "[periodic] Processing running encodes..."
+  bundle exec rake umd:process_running_encodes
+  echo "[periodic] Cleaning up local encode files older than ${older_than}..."
+  bundle exec rake avalon:local_encode_cleanup
+  echo "[periodic] Worker rake tasks completed at $(date). Sleeping for ${POLLING_INTERVAL} seconds."
+  sleep "${POLLING_INTERVAL}"
+done


### PR DESCRIPTION
- Override ActiveEncode::Polling with CustomPolling WatchedEncode to support distributed workers (polling job won't work across multiple instances).
- Added process_running_encodes Rake task to detect and process encode status updates on distributed workers every 5 minutes.
- Created worker_entrypoint.sh and worker_rake_tasks.sh scripts to run Sidekiq and periodic Rake tasks together in worker containers.

https://umd-dit.atlassian.net/browse/LIBAVALON-480