### PR TITLE
LIBAVALON-486. Refactor view courses implementation.

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -15,7 +15,6 @@
 class CoursesController < ApplicationController
   before_action :authenticate_user!
   before_action :auth, except: [:stop_impersonating]
-  before_action :auth_admin, only: [:impersonate]
 
   def index
     @courses = courses_list
@@ -58,10 +57,6 @@ class CoursesController < ApplicationController
 
     def auth
       current_ability.is_course_reserves_manager? || current_ability.is_administrator?
-    end
-
-    def auth_admin
-      current_ability.is_administrator?
     end
 
     def courses_list

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -57,7 +57,7 @@ class CoursesController < ApplicationController
   private
 
     def auth
-      current_ability.is_course_reserves_manager?
+      current_ability.is_course_reserves_manager? || current_ability.is_administrator?
     end
 
     def auth_admin

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -379,6 +379,10 @@ class Ability
   def self.course_reserves_collection
     @course_reserves_collection ||= Admin::Collection.all.find { |collection| collection&.unit == Settings.streaming_reserves.unit_name }
   end
+
+  def self.clear_course_reserves_collection_cache
+    @course_reserves_collection = nil
+  end
   # End UMD Customization
 
   def is_editor_of?(collection)

--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -83,8 +83,8 @@ class Admin::Collection < ActiveFedora::Base
   before_destroy :destroy_dropbox_directory!
 
   # UMD Customization
-  after_save :Ability.clear_course_reserves_collection_cache, if: :is_course_reserves?
-  after_destroy :Ability.clear_course_reserves_collection_cache, if: :is_course_reserves?
+  after_save(if: :is_course_reserves?) { Ability.clear_course_reserves_collection_cache }
+  after_destroy(if: :is_course_reserves?) { Ability.clear_course_reserves_collection_cache }
   # End UMD Customization
 
   def self.units

--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -233,7 +233,7 @@ class Admin::Collection < ActiveFedora::Base
   end
 
    # UMD Customization
-  def is_content_reserves?
+  def is_course_reserves?
     self.unit == Settings.streaming_reserves.unit_name
   end
 

--- a/app/models/admin/collection.rb
+++ b/app/models/admin/collection.rb
@@ -79,8 +79,13 @@ class Admin::Collection < ActiveFedora::Base
 
   around_save :reindex_members, if: Proc.new{ |c| c.name_changed? or c.unit_changed? }
   before_create :create_dropbox_directory!
-
+  
   before_destroy :destroy_dropbox_directory!
+
+  # UMD Customization
+  after_save :Ability.clear_course_reserves_collection_cache, if: :is_course_reserves?
+  after_destroy :Ability.clear_course_reserves_collection_cache, if: :is_course_reserves?
+  # End UMD Customization
 
   def self.units
     Avalon::ControlledVocabulary.find_by_name(:units, sort: true) || []

--- a/app/presenters/collection_presenter.rb
+++ b/app/presenters/collection_presenter.rb
@@ -67,7 +67,7 @@ class CollectionPresenter
     }
   end
 
-  def is_content_reserves?
+  def is_course_reserves?
     self.unit == Settings.streaming_reserves.unit_name
   end
 end

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -65,7 +65,7 @@ Unless required by applicable law or agreed to in writing, software distributed
           <li class="nav-item <%= active_for_controller('access_tokens') %>">
             <%= link_to 'Manage Access Tokens', main_app.access_tokens_path, class: 'nav-link' %></li>
           <% end %>
-          <% if current_ability.is_course_reserves_manager? %>
+          <% if current_ability.is_course_reserves_manager? || current_ability.is_administrator? %>
           <li class="nav-item <%= active_for_controller('courses') %>">
             <%= link_to 'View Courses', main_app.courses_path, class: 'nav-link' %></li>
           <% end %>

--- a/app/views/admin/collections/show.html.erb
+++ b/app/views/admin/collections/show.html.erb
@@ -86,7 +86,7 @@ Unless required by applicable law or agreed to in writing, software distributed
   <div class="well-vertical-spacer">
     <%= link_to('Create An Item', new_media_object_path(collection_id: @collection.id), class: 'btn btn-primary') if can? :create, MediaObject %>
     <%= link_to('List All Items', search_catalog_path('f[collection_ssim][]' => @collection.name), class: 'btn btn-outline') %>
-    <% if @collection.is_content_reserves? %>
+    <% if @collection.is_course_reserves? %>
       <%= link_to('Export Items', external_groups_admin_collection_path(@collection, format: 'csv'), class: 'btn btn-outline') %>
     <% end %>
     <%= button_tag('Edit Collection Info', class: 'btn btn-outline', data: {toggle:"modal", target:"#new_collection"}) if can? :update, @collection %>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -41,7 +41,7 @@ Unless required by applicable law or agreed to in writing, software distributed
       <div>
         <h3 class="sub-headline"><strong>Unit:</strong> <%= @doc_presenter.unit %></h3>
         <p class="lead document-description"></p>
-        <% if @doc_presenter.is_content_reserves? %>
+        <% if @doc_presenter.is_course_reserves? %>
           <%= link_to 'Show Course Reserves', course_reserves_collection_path(@doc_presenter.id), class: 'btn btn-primary' %>
         <% end %>
         <%= react_component("CollectionDetails",

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -46,9 +46,7 @@ Unless required by applicable law or agreed to in writing, software distributed
           <%= link_to 'Browse Course Items', search_catalog_path('f[course_title_ssim][]' => course.title), class: 'btn btn-outline' %>
         </td>
         <td>
-          <% if current_ability.is_administrator? %>
             <%= link_to 'Impersonate as course user', impersonate_course_path(course.context_id), method: :post, class: 'btn btn-outline' %>
-          <% end %>
         </td>
       </tr>
     <% end %>

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -371,5 +371,97 @@ describe Ability, type: :model do
       end
     end
   end
+
+  describe '.course_reserves_collection' do
+    let!(:course_reserves_collection) do
+      FactoryBot.create(:collection, unit: Settings.streaming_reserves.unit_name)
+    end
+    let!(:regular_collection) { FactoryBot.create(:collection, unit: 'Default Unit') }
+
+    it 'returns the collection with streaming_reserves unit' do
+      expect(Ability.course_reserves_collection).to eq(course_reserves_collection)
+    end
+
+    it 'returns nil if no course reserves collection exists' do
+      course_reserves_collection.destroy
+      expect(Ability.course_reserves_collection).to be_nil
+    end
+
+    it 'caches the result' do
+      # First call should query
+      result1 = Ability.course_reserves_collection
+      expect(result1).to eq(course_reserves_collection)
+      
+      # Subsequent calls should use cached value
+      expect(Admin::Collection).not_to receive(:all)
+      result2 = Ability.course_reserves_collection
+      expect(result2).to eq(course_reserves_collection)
+    end
+  end
+
+  describe '.clear_course_reserves_collection_cache' do
+    let!(:course_reserves_collection) do
+      FactoryBot.create(:collection, unit: Settings.streaming_reserves.unit_name)
+    end
+
+    it 'clears the cached course reserves collection' do
+      # Populate the cache
+      Ability.course_reserves_collection
+      
+      # Clear the cache
+      Ability.clear_course_reserves_collection_cache
+      
+      # Should query again
+      expect(Admin::Collection).to receive(:all).and_call_original
+      Ability.course_reserves_collection
+    end
+
+    it 'allows cache to be repopulated after clearing' do
+      # Populate the cache
+      first_result = Ability.course_reserves_collection
+      expect(first_result).to eq(course_reserves_collection)
+      
+      # Clear the cache
+      Ability.clear_course_reserves_collection_cache
+      
+      # Create a new course reserves collection with different name
+      course_reserves_collection.destroy
+      new_course_reserves_collection = FactoryBot.create(:collection, 
+        unit: Settings.streaming_reserves.unit_name, 
+        name: 'New Course Reserves')
+      
+      # Should return the new collection
+      second_result = Ability.course_reserves_collection
+      expect(second_result).to eq(new_course_reserves_collection)
+      expect(second_result).not_to eq(first_result)
+    end
+  end
+
+  describe '#is_course_reserves_manager?' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:manager) { FactoryBot.create(:manager) }
+    let!(:course_reserves_collection) do
+      FactoryBot.create(:collection, 
+        unit: Settings.streaming_reserves.unit_name,
+        managers: [manager.user_key])
+    end
+
+    it 'returns true for course reserves collection managers' do
+      ability = Ability.new(manager)
+      expect(ability.is_course_reserves_manager?).to be true
+    end
+
+    it 'returns false for non-managers' do
+      ability = Ability.new(user)
+      expect(ability.is_course_reserves_manager?).to be false
+    end
+
+    it 'returns false when no course reserves collection exists' do
+      course_reserves_collection.destroy
+      Ability.clear_course_reserves_collection_cache
+      ability = Ability.new(manager)
+      expect(ability.is_course_reserves_manager?).to be false
+    end
+  end
   # End UMD Customization
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -668,4 +668,101 @@ describe Admin::Collection do
       end
     end
   end
+
+  # UMD Customization
+  describe '#is_course_reserves?' do
+    let(:course_reserves_collection) do
+      FactoryBot.create(:collection, unit: Settings.streaming_reserves.unit_name)
+    end
+    let(:regular_collection) do
+      FactoryBot.create(:collection, unit: 'Default Unit')
+    end
+
+    it 'returns true for course reserves collections' do
+      expect(course_reserves_collection.is_course_reserves?).to be true
+    end
+
+    it 'returns false for non-course reserves collections' do
+      expect(regular_collection.is_course_reserves?).to be false
+    end
+  end
+
+  describe 'course reserves collection cache clearing' do
+    let(:course_reserves_collection) do
+      FactoryBot.create(:collection, unit: Settings.streaming_reserves.unit_name)
+    end
+
+    context 'after_save callback' do
+      it 'clears the cache when a course reserves collection is saved' do
+        # Allow during setup, then expect during the actual save
+        allow(Ability).to receive(:clear_course_reserves_collection_cache).and_call_original
+        course_reserves_collection # Create the collection (triggers callback)
+        
+        # Populate the cache
+        Ability.course_reserves_collection
+        
+        # Now expect the callback on the update
+        expect(Ability).to receive(:clear_course_reserves_collection_cache).and_call_original
+        course_reserves_collection.name = 'Updated Name'
+        course_reserves_collection.save!
+      end
+
+      it 'does not clear the cache when a non-course reserves collection is saved' do
+        # Non-course reserves collections should not trigger the callback at all
+        allow(Ability).to receive(:clear_course_reserves_collection_cache).and_call_original
+        regular_collection = FactoryBot.create(:collection, unit: 'Default Unit')
+        
+        expect(Ability).not_to receive(:clear_course_reserves_collection_cache)
+        regular_collection.name = 'Updated Name'
+        regular_collection.save!
+      end
+
+      it 'clears the cache when unit changes to streaming reserves' do
+        # Allow during initial creation
+        allow(Ability).to receive(:clear_course_reserves_collection_cache).and_call_original
+        regular_collection = FactoryBot.create(:collection, unit: 'Default Unit')
+        
+        # Expect when changing to course reserves unit
+        expect(Ability).to receive(:clear_course_reserves_collection_cache).and_call_original
+        regular_collection.unit = Settings.streaming_reserves.unit_name
+        regular_collection.save!
+      end
+    end
+
+    context 'after_destroy callback' do
+      it 'clears the cache when a course reserves collection is destroyed' do
+        # Allow during setup
+        allow(Ability).to receive(:clear_course_reserves_collection_cache).and_call_original
+        course_reserves_collection # Create the collection
+        
+        # Populate the cache
+        Ability.course_reserves_collection
+        
+        # Expect on destroy
+        expect(Ability).to receive(:clear_course_reserves_collection_cache).and_call_original
+        course_reserves_collection.destroy
+      end
+
+      it 'does not clear the cache when a non-course reserves collection is destroyed' do
+        allow(Ability).to receive(:clear_course_reserves_collection_cache).and_call_original
+        regular_collection = FactoryBot.create(:collection, unit: 'Default Unit')
+        
+        expect(Ability).not_to receive(:clear_course_reserves_collection_cache)
+        regular_collection.destroy
+      end
+
+      it 'checks is_course_reserves? state before destroy' do
+        # Allow during setup
+        allow(Ability).to receive(:clear_course_reserves_collection_cache).and_call_original
+        
+        # The callback should check the unit before destruction
+        expect(course_reserves_collection.is_course_reserves?).to be true
+        
+        # Expect on destroy
+        expect(Ability).to receive(:clear_course_reserves_collection_cache).and_call_original
+        course_reserves_collection.destroy
+      end
+    end
+  end
+  # End UMD Customization
 end

--- a/spec/presenters/collection_presenter_spec.rb
+++ b/spec/presenters/collection_presenter_spec.rb
@@ -121,4 +121,33 @@ describe CollectionPresenter do
       expect(presenter_json[:url]).to eq presenter.collection_url
     end
   end
+
+  # UMD Customization
+  describe '#is_course_reserves?' do
+    let(:course_reserves_doc) do
+      SolrDocument.new(
+        id: 'test123',
+        "name_ssi": 'Course Reserves Collection',
+        "unit_ssi": Settings.streaming_reserves.unit_name
+      )
+    end
+    let(:regular_doc) do
+      SolrDocument.new(
+        id: 'test456',
+        "name_ssi": 'Regular Collection',
+        "unit_ssi": 'Default Unit'
+      )
+    end
+
+    it 'returns true for course reserves collections' do
+      course_reserves_presenter = described_class.new(course_reserves_doc, view_context)
+      expect(course_reserves_presenter.is_course_reserves?).to be true
+    end
+
+    it 'returns false for non-course reserves collections' do
+      regular_presenter = described_class.new(regular_doc, view_context)
+      expect(regular_presenter.is_course_reserves?).to be false
+    end
+  end
+  # End UMD Customization
 end


### PR DESCRIPTION
- Fix Ability course reserves collection caching behavior to ensure updates to the collection invalidates the cache.
- Allow anyone with view courses privilege to impersonate as course user to see the student view. (currently course reserves managers and Avalon admins)
- Allow admins to view courses menu
- Rename `is_content_reserves?` to `is_course_reserves?` for consistency.

https://umd-dit.atlassian.net/browse/LIBAVALON-486