### PR TITLE
LIBAVALON-505. Improve Avalon memory management.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN         echo "deb     http://ftp.us.debian.org/debian/    bullseye main cont
          && cat /etc/apt/sources.list.d/nodesource.list \
          && cat /etc/apt/sources.list.d/yarn.list
 
+# UMD Customization - include libjemalloc2
 RUN         apt-get update && \
             apt-get -y dist-upgrade && \
             apt-get install -y --no-install-recommends --allow-unauthenticated \
@@ -77,8 +78,10 @@ RUN         apt-get update && \
             zip \
             dumb-init \
             libsqlite3-dev \
+            libjemalloc2 \
          && apt-get -y install mediainfo \
          && ln -s /usr/bin/lsof /usr/sbin/
+# End UMD Customization
 
 RUN         useradd -m -U app \
          && su -s /bin/bash -c "mkdir -p /home/app/avalon" app
@@ -146,7 +149,15 @@ COPY        --from=bundle-prod --chown=app:app /usr/local/bundle /usr/local/bund
 
 USER        app
 ENV         RAILS_ENV=production
+
 # UMD Customization
+# Enable jemalloc for better memory management in production
+ENV         LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+ENV         MALLOC_CONF="narenas:2,background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:0,tcache:true"
+
+# Enable YJIT for improved performance
+ENV RUBY_YJIT_ENABLE=1
+
 # Puma configuration for production
 ENV PUMA_WORKERS=4
 ENV PUMA_MIN_THREADS=5

--- a/Dockerfile
+++ b/Dockerfile
@@ -146,3 +146,9 @@ COPY        --from=bundle-prod --chown=app:app /usr/local/bundle /usr/local/bund
 
 USER        app
 ENV         RAILS_ENV=production
+# UMD Customization
+# Puma configuration for production
+ENV PUMA_WORKERS=4
+ENV PUMA_MIN_THREADS=5
+ENV PUMA_MAX_THREADS=5
+# End UMD Customization

--- a/Gemfile
+++ b/Gemfile
@@ -168,6 +168,9 @@ group :production do
   gem 'lograge'
   gem 'okcomputer'
   gem 'puma', '>= 6.4.2'
+  # UMD Customization
+  gem 'rbtrace', '~> 0.5.3'
+  # End UMD Customization
 end
 
 # Install the bundle --with aws when running on Amazon Elastic Beanstalk

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,6 +1,11 @@
 # Configure puma workers and threads based on CPU Limits
 cpu_limit = (Integer(ENV['CPU_LIMIT_IN_M']) / 1000) || 2
-workers cpu_limit
-max_threads_count = cpu_limit * 8
-min_threads_count = 8
+# UMD Customization
+workers_count = Integer(ENV['PUMA_WORKERS']) || cpu_limit
+# End UMD Customization
+workers workers_count
+# UMD Customization
+max_threads_count = Integer(ENV['PUMA_MAX_THREADS']) || cpu_limit * 8
+min_threads_count = Integer(ENV['PUMA_MIN_THREADS']) || 8
+# End UMD Customization
 threads min_threads_count, max_threads_count


### PR DESCRIPTION
LIBAVALON-506. Add rbtrace gem.

LIBAVALON-507. Made Puma worker and thread counts configurable.
-Also, added default values in Dockerfile.

LIBAVALON-508. Integrate jemalloc for memory management.
- Installed the jemalloc pacakge.
- Set LD_PRELOAD for ruby to use jemalloc
- Configure jemalloc settings using MALLOC_CONF
  - `narenas:2` - 2 memory arenas per worker.
  - `background_thread:true` - offload memory cleanup to a background thread
  - `dirty_decay_ms:1000` - Returns unused memory to the OS after a second
  - `muzzy_decay_ms:0` - Purge semi-unused memory pages immediately.
  - `tcache:true` - Keeps a small thread-local cache for memory allocations to make the small, frequent object allocations in Rails extremely fast
- Set `RUBY_YJIT_ENABLE=1` to improve performance (This is the default in the latest Ruby versions)

https://umd-dit.atlassian.net/browse/LIBAVALON-505