### PR TITLE
LIBAVALON-490. Add course id to course name in access control step.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -227,6 +227,13 @@ module ApplicationHelper
   end
 
   # UMD Customization
+  def vgroup_display_with_id value
+    c = Course.find_by_context_id(value)
+    c.nil? ? value : (content_tag(:i, "#{c.id}:") + ' ' + (c.title || c.label || value))
+  end
+  # End UMD Customization
+
+  # UMD Customization
   def umd_ip_manager_group_display(value)
     if value.is_a?(UmdIpManager::Group)
       # For groups without leases, just return the human-readable name for the

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -18,9 +18,9 @@ class Course < ActiveRecord::Base
   def self.autocomplete(query, _id = nil)
     # UMD Customization
     self.where("LOWER(label) LIKE :q OR LOWER(title) LIKE :q", q: "%#{query.downcase}%").collect { |course|
-    # End UMD Customization
-      { id: course.context_id, display: course.title }
+      { id: course.context_id, display: "#{course.id}: #{course.title}" }
     }
+    # End UMD Customization
   end
 
   def self.unlink_all(context_id)

--- a/app/views/modules/_special_access.html.erb
+++ b/app/views/modules/_special_access.html.erb
@@ -28,11 +28,13 @@ Unless required by applicable law or agreed to in writing, software distributed
           access_object: "group", members: @groups, leases: @group_leases,
           dropdown_values: [@addable_groups, 'name', 'name'],
           input_disabled: !can_update %>
+    <%# UMD Customization %>
     <%= render "modules/access_object", object: object,
           access_object: "class", members: @virtual_groups, leases: @virtual_leases,
           autocomplete_model: 'externalGroup',
-          display_helper: :vgroup_display,
+          display_helper: :vgroup_display_with_id,
           input_disabled: !can_update %>
+    <%# End UMD Customization %>
     <%= render "modules/access_object", object: object,
           access_object: "ipaddress", members: @ip_groups, leases: @ip_leases,
           input_disabled: !can_update %>


### PR DESCRIPTION
On the access control step, we will now prefix the course ID to the course title to distinguish courses when there are duplicate titles.

https://umd-dit.atlassian.net/browse/LIBAVALON-490