### PR TITLE
LIBAVALON-498. Limit read access to course reserves content.

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -117,7 +117,11 @@ class Ability
       # UMD Customization
       # Begin customization for LIBAVALON-168
       can :read, [MediaObject, SpeedyAF::Proxy::MediaObject] do |media_object|
-        media_object.published? || test_edit(media_object.id)
+        if media_object.is_streaming_reserve?
+          (test_read(media_object.id) && media_object.published?) || test_edit(media_object.id)
+        else
+          media_object.published? || test_edit(media_object.id)
+        end
       end
 
       # For media playback

--- a/app/models/media_object.rb
+++ b/app/models/media_object.rb
@@ -327,7 +327,8 @@ class MediaObject < ActiveFedora::Base
       solr_doc[Hydra.config.permissions.read.group] += solr_doc['read_access_ip_group_ssim']
       # UMD Customization
       solr_doc[Hydra.config.permissions.discover.group] ||= [] # Customization for LIBAVALON-168
-      solr_doc[Hydra.config.permissions.discover.group] += ['public'] # Customization for LIBAVALON-168
+       # Customization for LIBAVALON-168, LIBAVALON-498
+      solr_doc[Hydra.config.permissions.discover.group] += ['public'] unless is_streaming_reserve?
       # End UMD Customization
       solr_doc["title_ssort"] = self.title
       solr_doc["creator_ssort"] = Array(self.creator).join(', ')

--- a/app/presenters/speedy_af/proxy/media_object.rb
+++ b/app/presenters/speedy_af/proxy/media_object.rb
@@ -92,6 +92,12 @@ class SpeedyAF::Proxy::MediaObject < SpeedyAF::Base
     @collection ||= SpeedyAF::Proxy::Admin::Collection.find(collection_id)
   end
 
+  # UMD Customization
+  def is_streaming_reserve?
+    collection&.unit == Settings.streaming_reserves.unit_name
+  end
+  # End UMD Customization
+
   def lending_period
     attrs[:lending_period].presence || collection&.default_lending_period
   end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -154,6 +154,107 @@ describe Ability, type: :model do
     end
   end
 
+  # UMD Customization
+  describe "read Ability for streaming reserve items" do
+    context 'when media object is a streaming reserve' do
+      let(:streaming_collection) { FactoryBot.create(:collection, unit: Settings.streaming_reserves.unit_name) }
+
+      context 'and the media object is published' do
+        let(:media_object) do
+          FactoryBot.create(:published_media_object, collection: streaming_collection, visibility: 'private')
+        end
+
+        it 'is not readable by non-logged in users' do
+          ability = Ability.new(nil)
+          expect(ability).to_not be_able_to(:read, media_object)
+        end
+
+        it 'is not readable by ordinary logged in users without read access' do
+          ability = Ability.new(FactoryBot.create(:public))
+          expect(ability).to_not be_able_to(:read, media_object)
+        end
+
+        it 'is readable by users with read access (e.g., added to read_users)' do
+          user = FactoryBot.create(:user)
+          media_object.read_users += [user.user_key]
+          media_object.save!
+          ability = Ability.new(user)
+          expect(ability).to be_able_to(:read, media_object)
+        end
+
+        it 'is readable by admin users' do
+          ability = Ability.new(FactoryBot.create(:admin))
+          expect(ability).to be_able_to(:read, media_object)
+        end
+
+        it 'is readable by managers, editors, and depositors of the collection' do
+          collection_users = media_object.collection.managers +
+                            media_object.collection.editors +
+                            media_object.collection.depositors
+          collection_users.each do |user_name|
+            ability = Ability.new(User.find_by(username: user_name))
+            expect(ability).to be_able_to(:read, media_object)
+          end
+        end
+      end
+
+      context 'and the media object is unpublished' do
+        let(:media_object) do
+          FactoryBot.create(:media_object, collection: streaming_collection)
+        end
+
+        it 'is not readable by non-logged in users' do
+          ability = Ability.new(nil)
+          expect(ability).to_not be_able_to(:read, media_object)
+        end
+
+        it 'is still readable by users with explicit read access even when unpublished (Hydra base permissions)' do
+          user = FactoryBot.create(:user)
+          media_object.read_users += [user.user_key]
+          media_object.save!
+          ability = Ability.new(user)
+          expect(ability).to be_able_to(:read, media_object)
+        end
+
+        it 'is not readable by ordinary logged in users without read access' do
+          ability = Ability.new(FactoryBot.create(:public))
+          expect(ability).to_not be_able_to(:read, media_object)
+        end
+
+        it 'is readable by managers, editors, and depositors of the collection (via edit access)' do
+          collection_users = media_object.collection.managers +
+                            media_object.collection.editors +
+                            media_object.collection.depositors
+          collection_users.each do |user_name|
+            ability = Ability.new(User.find_by(username: user_name))
+            expect(ability).to be_able_to(:read, media_object)
+          end
+        end
+      end
+    end
+
+    context 'when media object is NOT a streaming reserve (regression)' do
+      let(:regular_collection) { FactoryBot.create(:collection, unit: 'Default Unit') }
+
+      context 'and the media object is published' do
+        let(:media_object) do
+          FactoryBot.create(:published_media_object, collection: regular_collection, visibility: 'private')
+        end
+
+        it 'is readable by non-logged in users even without read access' do
+          ability = Ability.new(nil)
+          expect(ability).to be_able_to(:read, media_object)
+        end
+
+        it 'is readable by ordinary logged in users without read access' do
+          ability = Ability.new(FactoryBot.create(:public))
+          expect(ability).to be_able_to(:read, media_object)
+        end
+      end
+    end
+  end
+  # End UMD Customization
+
   describe "stream Ability" do
     context 'when media object is unpublished' do
       let(:unpublished_media_object) { FactoryBot.create(:media_object) }

--- a/spec/presenters/speedy_af/proxy/media_object_spec.rb
+++ b/spec/presenters/speedy_af/proxy/media_object_spec.rb
@@ -105,4 +105,23 @@ describe SpeedyAF::Proxy::MediaObject do
       expect(presenter.sections.map(&:class)).to eq [SpeedyAF::Proxy::MasterFile, SpeedyAF::Proxy::MasterFile]
     end
   end
+
+  # UMD Customization
+  describe '#is_streaming_reserve?' do
+    context 'when the media object is in the streaming reserves unit' do
+      let(:collection) { FactoryBot.create(:collection, unit: Settings.streaming_reserves.unit_name) }
+      let(:media_object) { FactoryBot.create(:media_object, collection: collection) }
+
+      it 'returns true' do
+        expect(presenter.is_streaming_reserve?).to eq true
+      end
+    end
+
+    context 'when the media object is not in the streaming reserves unit' do
+      it 'returns false' do
+        expect(presenter.is_streaming_reserve?).to eq false
+      end
+    end
+  end
+  # End UMD Customization
 end


### PR DESCRIPTION
UMD has custom `read` and `full_read` abilities, and we grant `read` (non-streaming) access to all digital collections content. This change removes non-streaming metadata `read` access for Course Reserves content to public, so only users/groups specifically granted access can view the course reserves item detail page. That is, use the upstream Avalon's default behavior for course reserves content, and use the custom behavior for the rest of the content.

Alos, do not add `public` discover access for course reserves content, which is a custom behavior we added for digital collections content.

https://umd-dit.atlassian.net/browse/LIBAVALON-498