### PR TITLE
LIBAVALON-375. Added Job and rake task for S3 migration validation.

### DIFF
--- a/app/jobs/migrate_to_s3_job.rb
+++ b/app/jobs/migrate_to_s3_job.rb
@@ -3,6 +3,16 @@
 # Sidekiq job that migrates a single MasterFile and all its Derivatives
 # from the local filesystem to S3.
 #
+# The job operates in two phases:
+#   Phase 1 — Upload all files (MasterFile + Derivatives) to S3 with
+#             SHA-256 checksum verification, confirming existence and size.
+#   Phase 2 — Only after ALL uploads succeed, update the Avalon records
+#             with their new S3 locations.
+#
+# This ensures that a partial upload failure never leaves records pointing
+# at S3 objects that don't exist. On retry, already-uploaded objects will
+# be re-uploaded (S3 overwrites are atomic) and then records are updated.
+#
 # Usage:
 #   MigrateToS3Job.perform_later("master_file_id")
 #
@@ -28,28 +38,36 @@ class MigrateToS3Job < ActiveJob::Base
     Rails.logger.info "[S3Migration] Starting migration for MasterFile #{master_file_id}"
 
     master_file = MasterFile.find(master_file_id)
-    migrate_master_file!(master_file)
-    migrate_derivatives!(master_file)
+
+    # Phase 1: Upload all files to S3 and verify (no metadata changes yet)
+    master_file_s3_uri = upload_master_file(master_file)
+    derivative_s3_uris = upload_derivatives(master_file)
+
+    # Phase 2: Update Avalon records only after ALL uploads succeeded
+    save_master_file!(master_file, master_file_s3_uri)
+    save_derivatives!(derivative_s3_uris)
 
     Rails.logger.info "[S3Migration] Completed migration for MasterFile #{master_file_id}"
   end
 
   private
 
-    # ── MasterFile ──────────────────────────────────────────────────────
+    # ── Phase 1: Upload & Verify ────────────────────────────────────────
 
-    def migrate_master_file!(master_file)
+    # Uploads the MasterFile to S3 and verifies. Returns the S3 URI,
+    # or nil if the file was skipped (already migrated, blank, etc.).
+    def upload_master_file(master_file)
       file_location = master_file.file_location
 
       if file_location.blank?
         Rails.logger.info "[S3Migration] MasterFile #{master_file.id} has blank file_location, skipping"
-        return
+        return nil
       end
 
       # Only migrate local filesystem paths (not already S3, http, etc.)
       unless file_location.start_with?('/')
         Rails.logger.info "[S3Migration] MasterFile #{master_file.id} is not on local filesystem (#{truncate_path(file_location)}), skipping"
-        return
+        return nil
       end
 
       raise "Source file not found: #{file_location}" unless File.exist?(file_location)
@@ -69,39 +87,41 @@ class MigrateToS3Job < ActiveJob::Base
         raise "Size mismatch for MasterFile #{master_file.id}: expected #{expected}, got #{actual}" unless expected == actual
       end
 
-      # Atomic metadata update — this is the only moment of "transition"
-      master_file.file_location = s3_uri
-      master_file.save!
-
-      Rails.logger.info "[S3Migration] MasterFile #{master_file.id} migrated successfully"
+      Rails.logger.info "[S3Migration] MasterFile #{master_file.id} uploaded and verified"
+      s3_uri
     end
 
-    # ── Derivatives ─────────────────────────────────────────────────────
-
-    def migrate_derivatives!(master_file)
+    # Uploads all Derivatives to S3 and verifies. Returns an array of
+    # { derivative:, s3_uri: } hashes for those that were uploaded.
+    def upload_derivatives(master_file)
+      results = []
       master_file.derivatives.each do |derivative|
-        migrate_derivative!(derivative, master_file.id)
+        s3_uri = upload_derivative(derivative, master_file.id)
+        results << { derivative: derivative, s3_uri: s3_uri } if s3_uri
       end
+      results
     end
 
-    def migrate_derivative!(derivative, master_file_id)
+    # Uploads a single Derivative to S3 and verifies. Returns the S3 URI,
+    # or nil if skipped.
+    def upload_derivative(derivative, master_file_id)
       deriv_location = derivative.derivativeFile
 
       if deriv_location.blank?
         Rails.logger.info "[S3Migration] Derivative #{derivative.id} has blank location, skipping"
-        return
+        return nil
       end
 
       # Only migrate file:// derivatives (not already S3, http, etc.)
       unless deriv_location.start_with?('file://')
         Rails.logger.info "[S3Migration] Derivative #{derivative.id} is not file-based (#{truncate_path(deriv_location)}), skipping"
-        return
+        return nil
       end
 
       # Skip unmanaged derivatives — Avalon doesn't control their lifecycle
       unless derivative.managed
         Rails.logger.warn "[S3Migration] Derivative #{derivative.id} is unmanaged, skipping"
-        return
+        return nil
       end
 
       local_path = Addressable::URI.parse(deriv_location).path
@@ -120,12 +140,31 @@ class MigrateToS3Job < ActiveJob::Base
       actual     = s3_object.content_length
       raise "Size mismatch for Derivative #{derivative.id}: expected #{local_size}, got #{actual}" unless local_size == actual
 
-      # Setting absolute_location triggers set_streaming_locations! which
-      # recalculates location_url and hls_url for the S3-based path
-      derivative.absolute_location = s3_uri
-      derivative.save!
+      Rails.logger.info "[S3Migration] Derivative #{derivative.id} uploaded and verified"
+      s3_uri
+    end
 
-      Rails.logger.info "[S3Migration] Derivative #{derivative.id} migrated successfully"
+    # ── Phase 2: Update Avalon Records ──────────────────────────────────
+
+    def save_master_file!(master_file, s3_uri)
+      return if s3_uri.nil?
+
+      master_file.file_location = s3_uri
+      master_file.save!
+      Rails.logger.info "[S3Migration] MasterFile #{master_file.id} record updated to #{truncate_path(s3_uri)}"
+    end
+
+    def save_derivatives!(derivative_s3_uris)
+      derivative_s3_uris.each do |entry|
+        derivative = entry[:derivative]
+        s3_uri     = entry[:s3_uri]
+
+        # Setting absolute_location triggers set_streaming_locations! which
+        # recalculates location_url and hls_url for the S3-based path
+        derivative.absolute_location = s3_uri
+        derivative.save!
+        Rails.logger.info "[S3Migration] Derivative #{derivative.id} record updated to #{truncate_path(s3_uri)}"
+      end
     end
 
     # ── Path helpers ────────────────────────────────────────────────────

--- a/app/jobs/migrate_to_s3_job.rb
+++ b/app/jobs/migrate_to_s3_job.rb
@@ -111,7 +111,12 @@ class MigrateToS3Job < ActiveJob::Base
       s3_object = FileLocator::S3File.new(s3_uri).object
 
       Rails.logger.info "[S3Migration] Uploading MasterFile #{master_file.id}: #{truncate_path(file_location)} -> #{truncate_path(s3_uri)}"
-      s3_object.upload_file(file_location, checksum_algorithm: 'SHA256', part_size: MULTIPART_PART_SIZE)
+      # multipart_threshold must match MULTIPART_PART_SIZE so the SDK's own
+      # decision on single-part vs multipart always aligns with us passing
+      # part_size — put_object rejects part_size as an unexpected parameter.
+      upload_options = { checksum_algorithm: 'SHA256', multipart_threshold: MULTIPART_PART_SIZE }
+      upload_options[:part_size] = MULTIPART_PART_SIZE if File.size(file_location) >= MULTIPART_PART_SIZE
+      s3_object.upload_file(file_location, **upload_options)
 
       # Verify
       raise "Upload verification failed for MasterFile #{master_file.id}" unless s3_object.exists?
@@ -172,7 +177,9 @@ class MigrateToS3Job < ActiveJob::Base
       s3_object = FileLocator::S3File.new(s3_uri).object
 
       Rails.logger.info "[S3Migration] Uploading Derivative #{derivative.id}: #{truncate_path(local_path)} -> #{truncate_path(s3_uri)}"
-      s3_object.upload_file(local_path, checksum_algorithm: 'SHA256', part_size: MULTIPART_PART_SIZE)
+      upload_options = { checksum_algorithm: 'SHA256', multipart_threshold: MULTIPART_PART_SIZE }
+      upload_options[:part_size] = MULTIPART_PART_SIZE if File.size(local_path) >= MULTIPART_PART_SIZE
+      s3_object.upload_file(local_path, **upload_options)
 
       # Verify
       raise "Upload verification failed for Derivative #{derivative.id}" unless s3_object.exists?

--- a/app/jobs/migrate_to_s3_job.rb
+++ b/app/jobs/migrate_to_s3_job.rb
@@ -30,6 +30,11 @@
 class MigrateToS3Job < ActiveJob::Base
   queue_as :s3_migration
 
+  # Multipart upload part size (default 64 MB). Configurable via env var
+  # so each environment can tune for throughput. Must match the value used
+  # by S3_VALIDATION_PART_SIZE_MB when validating checksums.
+  MULTIPART_PART_SIZE = (ENV.fetch('S3_MIGRATION_PART_SIZE_MB', '64').to_i * 1024 * 1024)
+
   # Retry transient S3 / network errors with exponential backoff
   retry_on Aws::S3::Errors::ServiceError, wait: :polynomially_longer, attempts: 5
   retry_on Errno::ECONNRESET,             wait: :polynomially_longer, attempts: 5
@@ -106,7 +111,7 @@ class MigrateToS3Job < ActiveJob::Base
       s3_object = FileLocator::S3File.new(s3_uri).object
 
       Rails.logger.info "[S3Migration] Uploading MasterFile #{master_file.id}: #{truncate_path(file_location)} -> #{truncate_path(s3_uri)}"
-      s3_object.upload_file(file_location, checksum_algorithm: 'SHA256')
+      s3_object.upload_file(file_location, checksum_algorithm: 'SHA256', part_size: MULTIPART_PART_SIZE)
 
       # Verify
       raise "Upload verification failed for MasterFile #{master_file.id}" unless s3_object.exists?
@@ -167,7 +172,7 @@ class MigrateToS3Job < ActiveJob::Base
       s3_object = FileLocator::S3File.new(s3_uri).object
 
       Rails.logger.info "[S3Migration] Uploading Derivative #{derivative.id}: #{truncate_path(local_path)} -> #{truncate_path(s3_uri)}"
-      s3_object.upload_file(local_path, checksum_algorithm: 'SHA256')
+      s3_object.upload_file(local_path, checksum_algorithm: 'SHA256', part_size: MULTIPART_PART_SIZE)
 
       # Verify
       raise "Upload verification failed for Derivative #{derivative.id}" unless s3_object.exists?

--- a/app/jobs/migrate_to_s3_job.rb
+++ b/app/jobs/migrate_to_s3_job.rb
@@ -40,12 +40,15 @@ class MigrateToS3Job < ActiveJob::Base
     master_file = MasterFile.find(master_file_id)
 
     # Phase 1: Upload all files to S3 and verify (no metadata changes yet)
-    master_file_s3_uri = upload_master_file(master_file)
-    derivative_s3_uris = upload_derivatives(master_file)
+    master_file_upload = upload_master_file(master_file)
+    derivative_uploads = upload_derivatives(master_file)
 
     # Phase 2: Update Avalon records only after ALL uploads succeeded
-    save_master_file!(master_file, master_file_s3_uri)
-    save_derivatives!(derivative_s3_uris)
+    save_master_file!(master_file, master_file_upload)
+    save_derivatives!(derivative_uploads)
+
+    # Phase 3: Write audit trail (single record for MasterFile + Derivatives)
+    log_migration_audit(master_file, master_file_upload, derivative_uploads)
 
     Rails.logger.info "[S3Migration] Completed migration for MasterFile #{master_file_id}"
   end
@@ -54,8 +57,8 @@ class MigrateToS3Job < ActiveJob::Base
 
     # ── Phase 1: Upload & Verify ────────────────────────────────────────
 
-    # Uploads the MasterFile to S3 and verifies. Returns the S3 URI,
-    # or nil if the file was skipped (already migrated, blank, etc.).
+    # Uploads the MasterFile to S3 and verifies. Returns a hash with
+    # upload details, or nil if the file was skipped.
     def upload_master_file(master_file)
       file_location = master_file.file_location
 
@@ -81,29 +84,29 @@ class MigrateToS3Job < ActiveJob::Base
       # Verify
       raise "Upload verification failed for MasterFile #{master_file.id}" unless s3_object.exists?
 
+      file_size = s3_object.content_length
       if master_file.file_size.present?
         expected = master_file.file_size.to_i
-        actual   = s3_object.content_length
-        raise "Size mismatch for MasterFile #{master_file.id}: expected #{expected}, got #{actual}" unless expected == actual
+        raise "Size mismatch for MasterFile #{master_file.id}: expected #{expected}, got #{file_size}" unless expected == file_size
       end
 
       Rails.logger.info "[S3Migration] MasterFile #{master_file.id} uploaded and verified"
-      s3_uri
+      { s3_uri: s3_uri, source_path: file_location, file_size: file_size }
     end
 
     # Uploads all Derivatives to S3 and verifies. Returns an array of
-    # { derivative:, s3_uri: } hashes for those that were uploaded.
+    # upload detail hashes for those that were uploaded.
     def upload_derivatives(master_file)
       results = []
       master_file.derivatives.each do |derivative|
-        s3_uri = upload_derivative(derivative, master_file.id)
-        results << { derivative: derivative, s3_uri: s3_uri } if s3_uri
+        result = upload_derivative(derivative, master_file.id)
+        results << result if result
       end
       results
     end
 
-    # Uploads a single Derivative to S3 and verifies. Returns the S3 URI,
-    # or nil if skipped.
+    # Uploads a single Derivative to S3 and verifies. Returns a hash
+    # with upload details, or nil if skipped.
     def upload_derivative(derivative, master_file_id)
       deriv_location = derivative.derivativeFile
 
@@ -136,26 +139,26 @@ class MigrateToS3Job < ActiveJob::Base
       # Verify
       raise "Upload verification failed for Derivative #{derivative.id}" unless s3_object.exists?
 
+      file_size  = s3_object.content_length
       local_size = File.size(local_path)
-      actual     = s3_object.content_length
-      raise "Size mismatch for Derivative #{derivative.id}: expected #{local_size}, got #{actual}" unless local_size == actual
+      raise "Size mismatch for Derivative #{derivative.id}: expected #{local_size}, got #{file_size}" unless local_size == file_size
 
       Rails.logger.info "[S3Migration] Derivative #{derivative.id} uploaded and verified"
-      s3_uri
+      { derivative: derivative, s3_uri: s3_uri, source_path: local_path, file_size: file_size }
     end
 
     # ── Phase 2: Update Avalon Records ──────────────────────────────────
 
-    def save_master_file!(master_file, s3_uri)
-      return if s3_uri.nil?
+    def save_master_file!(master_file, upload)
+      return if upload.nil?
 
-      master_file.file_location = s3_uri
+      master_file.file_location = upload[:s3_uri]
       master_file.save!
-      Rails.logger.info "[S3Migration] MasterFile #{master_file.id} record updated to #{truncate_path(s3_uri)}"
+      Rails.logger.info "[S3Migration] MasterFile #{master_file.id} record updated to #{truncate_path(upload[:s3_uri])}"
     end
 
-    def save_derivatives!(derivative_s3_uris)
-      derivative_s3_uris.each do |entry|
+    def save_derivatives!(derivative_uploads)
+      derivative_uploads.each do |entry|
         derivative = entry[:derivative]
         s3_uri     = entry[:s3_uri]
 
@@ -165,6 +168,61 @@ class MigrateToS3Job < ActiveJob::Base
         derivative.save!
         Rails.logger.info "[S3Migration] Derivative #{derivative.id} record updated to #{truncate_path(s3_uri)}"
       end
+    end
+
+    # ── Phase 3: Audit Trail ───────────────────────────────────────────
+
+    # Write a single audit record containing the MasterFile and all its
+    # Derivatives, keyed by the MasterFile ID.
+    def log_migration_audit(master_file, master_file_upload, derivative_uploads)
+      media_object_id = master_file.media_object&.id
+
+      mf_entry = nil
+      if master_file_upload
+        mf_entry = {
+          source_path:    master_file_upload[:source_path],
+          destination_uri: master_file_upload[:s3_uri],
+          file_size:      master_file_upload[:file_size],
+          checksum:       fetch_s3_checksum(master_file_upload[:s3_uri]),
+          checksum_type:  'SHA256'
+        }
+      end
+
+      deriv_entries = derivative_uploads.map do |entry|
+        {
+          resource_id:    entry[:derivative].id,
+          source_path:    entry[:source_path],
+          destination_uri: entry[:s3_uri],
+          file_size:      entry[:file_size],
+          checksum:       fetch_s3_checksum(entry[:s3_uri]),
+          checksum_type:  'SHA256'
+        }
+      end
+
+      S3MigrationLogger.log_master_file_migration(
+        master_file_id:  master_file.id,
+        media_object_id: media_object_id,
+        master_file:     mf_entry,
+        derivatives:     deriv_entries
+      )
+    rescue => e
+      # Audit logging failure should not fail the migration itself
+      Rails.logger.warn "[S3Migration] Failed to log audit entry for MasterFile #{master_file.id}: #{e.message}"
+    end
+
+    # Fetch the SHA-256 checksum stored on the S3 object after upload.
+    # Returns nil if the checksum cannot be retrieved.
+    def fetch_s3_checksum(s3_uri)
+      s3_object = FileLocator::S3File.new(s3_uri).object
+      resp = s3_object.client.head_object(
+        bucket: s3_object.bucket_name,
+        key:    s3_object.key,
+        checksum_mode: 'ENABLED'
+      )
+      resp.checksum_sha256
+    rescue => e
+      Rails.logger.warn "[S3Migration] Could not fetch checksum for #{truncate_path(s3_uri)}: #{e.message}"
+      nil
     end
 
     # ── Path helpers ────────────────────────────────────────────────────

--- a/app/jobs/migrate_to_s3_job.rb
+++ b/app/jobs/migrate_to_s3_job.rb
@@ -9,6 +9,11 @@
 #   Phase 2 — Only after ALL uploads succeed, update the Avalon records
 #             with their new S3 locations.
 #
+# Partial migration: If the MasterFile source file is missing from the
+# local filesystem but Derivatives are present, the job uploads and updates
+# the Derivatives while leaving the MasterFile record unchanged. This is
+# logged as a "partial" migration in the audit trail.
+#
 # This ensures that a partial upload failure never leaves records pointing
 # at S3 objects that don't exist. On retry, already-uploaded objects will
 # be re-uploaded (S3 overwrites are atomic) and then records are updated.
@@ -43,14 +48,33 @@ class MigrateToS3Job < ActiveJob::Base
     master_file_upload = upload_master_file(master_file)
     derivative_uploads = upload_derivatives(master_file)
 
-    # Phase 2: Update Avalon records only after ALL uploads succeeded
-    save_master_file!(master_file, master_file_upload)
+    # Mark as failed if derivative uploads contains nil entries
+    if derivative_uploads.any?(&:nil?)
+      Rails.logger.warn "[S3Migration] One or more derivatives for MasterFile #{master_file_id} failed to upload, aborting migration"
+      return
+    end
+
+    masterfile_non_migrateable = master_file_upload.is_a?(Hash) && [:source_missing, :non_local].include?(master_file_upload[:status])
+    if derivative_uploads.all? { |u| u[:status] == :already_migrated } && masterfile_non_migrateable
+      Rails.logger.info "[S3Migration] All derivatives for MasterFile #{master_file_id} already migrated and masterfile non-migrateable, skipping"
+      return
+    end
+
+    # Detect partial migration: MasterFile source missing but derivatives uploaded
+    partial = masterfile_non_migrateable
+
+    # Phase 2: Update Avalon records only after uploads succeeded
+    save_master_file!(master_file, master_file_upload) unless partial
     save_derivatives!(derivative_uploads)
 
     # Phase 3: Write audit trail (single record for MasterFile + Derivatives)
-    log_migration_audit(master_file, master_file_upload, derivative_uploads)
+    log_migration_audit(master_file, master_file_upload, derivative_uploads, partial: partial)
 
-    Rails.logger.info "[S3Migration] Completed migration for MasterFile #{master_file_id}"
+    if partial
+      Rails.logger.warn "[S3Migration] Partial migration for MasterFile #{master_file_id}: source file missing, derivatives migrated"
+    else
+      Rails.logger.info "[S3Migration] Completed migration for MasterFile #{master_file_id}"
+    end
   end
 
   private
@@ -64,16 +88,19 @@ class MigrateToS3Job < ActiveJob::Base
 
       if file_location.blank?
         Rails.logger.info "[S3Migration] MasterFile #{master_file.id} has blank file_location, skipping"
-        return nil
+        return { status: :source_missing, source_path: nil }
       end
 
       # Only migrate local filesystem paths (not already S3, http, etc.)
       unless file_location.start_with?('/')
         Rails.logger.info "[S3Migration] MasterFile #{master_file.id} is not on local filesystem (#{truncate_path(file_location)}), skipping"
-        return nil
+        return { status: :non_local, source_path: file_location }
       end
 
-      raise "Source file not found: #{file_location}" unless File.exist?(file_location)
+      unless File.exist?(file_location)
+        Rails.logger.warn "[S3Migration] MasterFile #{master_file.id} source file not found: #{file_location}"
+        return { status: :source_missing, source_path: file_location }
+      end
 
       s3_uri    = masterfile_s3_uri(file_location)
       s3_object = FileLocator::S3File.new(s3_uri).object
@@ -113,6 +140,12 @@ class MigrateToS3Job < ActiveJob::Base
       if deriv_location.blank?
         Rails.logger.info "[S3Migration] Derivative #{derivative.id} has blank location, skipping"
         return nil
+      end
+
+      # If already in S3
+      if deriv_location.start_with?('s3://')
+        Rails.logger.info "[S3Migration] Derivative #{derivative.id} already in S3 (#{truncate_path(deriv_location)}), skipping"
+        return { derivative: derivative, s3_uri: deriv_location, status: :already_migrated }
       end
 
       # Only migrate file:// derivatives (not already S3, http, etc.)
@@ -174,18 +207,30 @@ class MigrateToS3Job < ActiveJob::Base
 
     # Write a single audit record containing the MasterFile and all its
     # Derivatives, keyed by the MasterFile ID.
-    def log_migration_audit(master_file, master_file_upload, derivative_uploads)
+    def log_migration_audit(master_file, master_file_upload, derivative_uploads, partial: false)
       media_object_id = master_file.media_object&.id
 
       mf_entry = nil
       if master_file_upload
-        mf_entry = {
-          source_path:    master_file_upload[:source_path],
-          destination_uri: master_file_upload[:s3_uri],
-          file_size:      master_file_upload[:file_size],
-          checksum:       fetch_s3_checksum(master_file_upload[:s3_uri]),
-          checksum_type:  'SHA256'
-        }
+        if [:source_missing, :non_local].include?(master_file_upload[:status])
+          # Partial migration: record the missing source file
+          mf_entry = {
+            source_path:    master_file_upload[:source_path],
+            destination_uri: nil,
+            file_size:      nil,
+            checksum:       nil,
+            checksum_type:  nil,
+            status:         'partial'
+          }
+        else
+          mf_entry = {
+            source_path:    master_file_upload[:source_path],
+            destination_uri: master_file_upload[:s3_uri],
+            file_size:      master_file_upload[:file_size],
+            checksum:       fetch_s3_checksum(master_file_upload[:s3_uri]),
+            checksum_type:  'SHA256'
+          }
+        end
       end
 
       deriv_entries = derivative_uploads.map do |entry|

--- a/app/jobs/migrate_to_s3_job.rb
+++ b/app/jobs/migrate_to_s3_job.rb
@@ -53,12 +53,6 @@ class MigrateToS3Job < ActiveJob::Base
     master_file_upload = upload_master_file(master_file)
     derivative_uploads = upload_derivatives(master_file)
 
-    # Mark as failed if derivative uploads contains nil entries
-    if derivative_uploads.any?(&:nil?)
-      Rails.logger.warn "[S3Migration] One or more derivatives for MasterFile #{master_file_id} failed to upload, aborting migration"
-      return
-    end
-
     masterfile_non_migrateable = master_file_upload.is_a?(Hash) && [:source_missing, :non_local].include?(master_file_upload[:status])
     if derivative_uploads.all? { |u| u[:status] == :already_migrated } && masterfile_non_migrateable
       Rails.logger.info "[S3Migration] All derivatives for MasterFile #{master_file_id} already migrated and masterfile non-migrateable, skipping"
@@ -128,7 +122,7 @@ class MigrateToS3Job < ActiveJob::Base
       end
 
       Rails.logger.info "[S3Migration] MasterFile #{master_file.id} uploaded and verified"
-      { s3_uri: s3_uri, source_path: file_location, file_size: file_size }
+      { s3_uri: s3_uri, source_path: file_location, file_size: file_size, status: :success }
     end
 
     # Uploads all Derivatives to S3 and verifies. Returns an array of
@@ -136,38 +130,45 @@ class MigrateToS3Job < ActiveJob::Base
     def upload_derivatives(master_file)
       results = []
       master_file.derivatives.each do |derivative|
-        result = upload_derivative(derivative, master_file.id)
-        results << result if result
+        results << upload_derivative(derivative, master_file.id)
       end
       results
     end
 
-    # Uploads a single Derivative to S3 and verifies. Returns a hash
-    # with upload details, or nil if skipped.
+    # Uploads a single Derivative to S3 and verifies. Returns a hash with
+    # upload details (:success) or {:already_migrated} if already on S3.
+    # Raises for all other conditions (:source_missing, :non_local, :unmanaged)
+    # so the entire job fails rather than silently skipping a derivative.
     def upload_derivative(derivative, master_file_id)
       deriv_location = derivative.derivativeFile
 
       if deriv_location.blank?
-        Rails.logger.info "[S3Migration] Derivative #{derivative.id} has blank location, skipping"
-        return nil
+        raise "[S3Migration] Derivative #{derivative.id} has blank location, cannot migrate MasterFile #{master_file_id}"
       end
 
       # If already in S3
       if deriv_location.start_with?('s3://')
         Rails.logger.info "[S3Migration] Derivative #{derivative.id} already in S3 (#{truncate_path(deriv_location)}), skipping"
-        return { derivative: derivative, s3_uri: deriv_location, status: :already_migrated }
+        s3_object = FileLocator::S3File.new(deriv_location).object
+        file_size = begin
+          s3_object.content_length
+        rescue => e
+          Rails.logger.warn "[S3Migration] Could not fetch file_size for #{deriv_location}: #{e.message}"
+          nil
+        end
+        return { derivative: derivative, s3_uri: deriv_location,
+                 source_path: reverse_derivative_s3_uri(deriv_location),
+                 file_size: file_size, status: :already_migrated }
       end
 
       # Only migrate file:// derivatives (not already S3, http, etc.)
       unless deriv_location.start_with?('file://')
-        Rails.logger.info "[S3Migration] Derivative #{derivative.id} is not file-based (#{truncate_path(deriv_location)}), skipping"
-        return nil
+        raise "[S3Migration] Derivative #{derivative.id} is not file-based (#{truncate_path(deriv_location)}), cannot migrate MasterFile #{master_file_id}"
       end
 
-      # Skip unmanaged derivatives — Avalon doesn't control their lifecycle
+      # Unmanaged derivatives — Avalon doesn't control their lifecycle
       unless derivative.managed
-        Rails.logger.warn "[S3Migration] Derivative #{derivative.id} is unmanaged, skipping"
-        return nil
+        raise "[S3Migration] Derivative #{derivative.id} is unmanaged, cannot migrate MasterFile #{master_file_id}"
       end
 
       local_path = Addressable::URI.parse(deriv_location).path
@@ -189,7 +190,7 @@ class MigrateToS3Job < ActiveJob::Base
       raise "Size mismatch for Derivative #{derivative.id}: expected #{local_size}, got #{file_size}" unless local_size == file_size
 
       Rails.logger.info "[S3Migration] Derivative #{derivative.id} uploaded and verified"
-      { derivative: derivative, s3_uri: s3_uri, source_path: local_path, file_size: file_size }
+      { derivative: derivative, s3_uri: s3_uri, source_path: local_path, file_size: file_size, status: :success }
     end
 
     # ── Phase 2: Update Avalon Records ──────────────────────────────────
@@ -204,6 +205,9 @@ class MigrateToS3Job < ActiveJob::Base
 
     def save_derivatives!(derivative_uploads)
       derivative_uploads.each do |entry|
+        # Only update records for derivatives that were actually uploaded
+        next unless entry[:status] == :success
+
         derivative = entry[:derivative]
         s3_uri     = entry[:s3_uri]
 
@@ -245,7 +249,8 @@ class MigrateToS3Job < ActiveJob::Base
         end
       end
 
-      deriv_entries = derivative_uploads.map do |entry|
+      # Only derivatives that reached S3 (uploaded this run or already there)
+      deriv_entries = derivative_uploads.select { |e| %i[success already_migrated].include?(e[:status]) }.map do |entry|
         {
           resource_id:    entry[:derivative].id,
           source_path:    entry[:source_path],
@@ -313,6 +318,18 @@ class MigrateToS3Job < ActiveJob::Base
     def derivative_local_base
       ENV.fetch('MIGRATE_DERIVATIVE_LOCAL_BASE',
                  ENV.fetch('LOCAL_DERIVATIVES_DIR', '/streamfiles'))
+    end
+
+    # Reverse a derivative S3 URI back to the expected local path.
+    # Used when the DB record already points at S3 (re-run scenario) and
+    # we want to preserve source_path in the audit trail.
+    # e.g. s3://bucket/uuid/outputs/name-high.mp4 -> /streamfiles/uuid/outputs/name-high.mp4
+    def reverse_derivative_s3_uri(s3_uri)
+      uri = Addressable::URI.parse(s3_uri)
+      key = Addressable::URI.unencode(uri.path).sub(%r{^/}, '')
+      File.join(derivative_local_base, key)
+    rescue
+      nil
     end
 
     def truncate_path(path, max: 80)

--- a/app/jobs/migrate_to_s3_job.rb
+++ b/app/jobs/migrate_to_s3_job.rb
@@ -1,0 +1,168 @@
+# UMD Customization
+#
+# Sidekiq job that migrates a single MasterFile and all its Derivatives
+# from the local filesystem to S3.
+#
+# Usage:
+#   MigrateToS3Job.perform_later("master_file_id")
+#
+# The job is idempotent — re-running it for an already-migrated MasterFile
+# is a safe no-op. This makes the migration resumable: simply re-enqueue
+# all candidates and already-completed items will be skipped.
+#
+# Queue: s3_migration (processed by dedicated migration workers only)
+#
+class MigrateToS3Job < ActiveJob::Base
+  queue_as :s3_migration
+
+  # Retry transient S3 / network errors with exponential backoff
+  retry_on Aws::S3::Errors::ServiceError, wait: :polynomially_longer, attempts: 5
+  retry_on Errno::ECONNRESET,             wait: :polynomially_longer, attempts: 5
+  retry_on Net::OpenTimeout,              wait: :polynomially_longer, attempts: 5
+  retry_on Faraday::ConnectionFailed,     wait: :polynomially_longer, attempts: 5
+
+  # Discard if the object was deleted between enqueue and execution
+  discard_on ActiveFedora::ObjectNotFoundError
+
+  def perform(master_file_id)
+    Rails.logger.info "[S3Migration] Starting migration for MasterFile #{master_file_id}"
+
+    master_file = MasterFile.find(master_file_id)
+    migrate_master_file!(master_file)
+    migrate_derivatives!(master_file)
+
+    Rails.logger.info "[S3Migration] Completed migration for MasterFile #{master_file_id}"
+  end
+
+  private
+
+    # ── MasterFile ──────────────────────────────────────────────────────
+
+    def migrate_master_file!(master_file)
+      file_location = master_file.file_location
+
+      if file_location.blank?
+        Rails.logger.info "[S3Migration] MasterFile #{master_file.id} has blank file_location, skipping"
+        return
+      end
+
+      # Only migrate local filesystem paths (not already S3, http, etc.)
+      unless file_location.start_with?('/')
+        Rails.logger.info "[S3Migration] MasterFile #{master_file.id} is not on local filesystem (#{truncate_path(file_location)}), skipping"
+        return
+      end
+
+      raise "Source file not found: #{file_location}" unless File.exist?(file_location)
+
+      s3_uri    = masterfile_s3_uri(file_location)
+      s3_object = FileLocator::S3File.new(s3_uri).object
+
+      Rails.logger.info "[S3Migration] Uploading MasterFile #{master_file.id}: #{truncate_path(file_location)} -> #{truncate_path(s3_uri)}"
+      s3_object.upload_file(file_location, checksum_algorithm: 'SHA256')
+
+      # Verify
+      raise "Upload verification failed for MasterFile #{master_file.id}" unless s3_object.exists?
+
+      if master_file.file_size.present?
+        expected = master_file.file_size.to_i
+        actual   = s3_object.content_length
+        raise "Size mismatch for MasterFile #{master_file.id}: expected #{expected}, got #{actual}" unless expected == actual
+      end
+
+      # Atomic metadata update — this is the only moment of "transition"
+      master_file.file_location = s3_uri
+      master_file.save!
+
+      Rails.logger.info "[S3Migration] MasterFile #{master_file.id} migrated successfully"
+    end
+
+    # ── Derivatives ─────────────────────────────────────────────────────
+
+    def migrate_derivatives!(master_file)
+      master_file.derivatives.each do |derivative|
+        migrate_derivative!(derivative, master_file.id)
+      end
+    end
+
+    def migrate_derivative!(derivative, master_file_id)
+      deriv_location = derivative.derivativeFile
+
+      if deriv_location.blank?
+        Rails.logger.info "[S3Migration] Derivative #{derivative.id} has blank location, skipping"
+        return
+      end
+
+      # Only migrate file:// derivatives (not already S3, http, etc.)
+      unless deriv_location.start_with?('file://')
+        Rails.logger.info "[S3Migration] Derivative #{derivative.id} is not file-based (#{truncate_path(deriv_location)}), skipping"
+        return
+      end
+
+      # Skip unmanaged derivatives — Avalon doesn't control their lifecycle
+      unless derivative.managed
+        Rails.logger.warn "[S3Migration] Derivative #{derivative.id} is unmanaged, skipping"
+        return
+      end
+
+      local_path = Addressable::URI.parse(deriv_location).path
+      raise "Derivative source not found: #{local_path}" unless File.exist?(local_path)
+
+      s3_uri    = derivative_s3_uri(local_path)
+      s3_object = FileLocator::S3File.new(s3_uri).object
+
+      Rails.logger.info "[S3Migration] Uploading Derivative #{derivative.id}: #{truncate_path(local_path)} -> #{truncate_path(s3_uri)}"
+      s3_object.upload_file(local_path, checksum_algorithm: 'SHA256')
+
+      # Verify
+      raise "Upload verification failed for Derivative #{derivative.id}" unless s3_object.exists?
+
+      local_size = File.size(local_path)
+      actual     = s3_object.content_length
+      raise "Size mismatch for Derivative #{derivative.id}: expected #{local_size}, got #{actual}" unless local_size == actual
+
+      # Setting absolute_location triggers set_streaming_locations! which
+      # recalculates location_url and hls_url for the S3-based path
+      derivative.absolute_location = s3_uri
+      derivative.save!
+
+      Rails.logger.info "[S3Migration] Derivative #{derivative.id} migrated successfully"
+    end
+
+    # ── Path helpers ────────────────────────────────────────────────────
+
+    # Convert local masterfile path to S3 URI
+    # e.g. /masterfiles/archive/2v/23/vt/36/id-file.mp4
+    #   -> s3://bucket/archive/2v/23/vt/36/id-file.mp4
+    def masterfile_s3_uri(file_location)
+      base = masterfile_local_base
+      relative_key = file_location.sub(%r{^#{Regexp.escape(base)}/?}, '')
+      "s3://#{Settings.encoding.masterfile_bucket}/#{relative_key}"
+    end
+
+    # Convert local derivative path to S3 URI
+    # e.g. /streamfiles/uuid/outputs/name-high.mp4
+    #   -> s3://bucket/uuid/outputs/name-high.mp4
+    def derivative_s3_uri(local_path)
+      base = derivative_local_base
+      relative_key = local_path.sub(%r{^#{Regexp.escape(base)}/?}, '')
+      "s3://#{Settings.encoding.derivative_bucket}/#{relative_key}"
+    end
+
+    # The local filesystem root for archived master files.
+    # In K8s the PVC is mounted at /masterfiles.
+    def masterfile_local_base
+      ENV.fetch('MIGRATE_MASTERFILE_LOCAL_BASE', '/masterfiles')
+    end
+
+    # The local filesystem root for derivative/streaming files.
+    # In K8s the PVC is mounted at /streamfiles.
+    def derivative_local_base
+      ENV.fetch('MIGRATE_DERIVATIVE_LOCAL_BASE',
+                 ENV.fetch('LOCAL_DERIVATIVES_DIR', '/streamfiles'))
+    end
+
+    def truncate_path(path, max: 80)
+      path.length > max ? "#{path[0..40]}...#{path[-35..]}" : path
+    end
+end
+# End UMD Customization

--- a/app/jobs/validate_s3_migration_job.rb
+++ b/app/jobs/validate_s3_migration_job.rb
@@ -1,0 +1,274 @@
+# UMD Customization
+#
+# Sidekiq job that validates a single MasterFile (and its Derivatives)
+# were correctly migrated to S3 by comparing local-disk SHA-256 checksums
+# with the checksums stored on the S3 objects.
+#
+# This is designed to run as a *secondary* verification step AFTER the
+# migration is complete, while the original local files still exist on disk.
+#
+# Validation checks per file:
+#   1. S3 object exists
+#   2. Size matches local file
+#   3. SHA-256 checksum matches (handles both single-part and multipart uploads)
+#
+# Usage:
+#   ValidateS3MigrationJob.perform_later("master_file_id")
+#
+# The job is idempotent and safe to re-run. Files that are not on S3 or
+# whose local path no longer exists are skipped (not failures).
+#
+# Queue: s3_validation (processed by dedicated validation workers only)
+#
+class ValidateS3MigrationJob < ActiveJob::Base
+  queue_as :s3_validation
+
+  # Retry transient S3 / network errors with exponential backoff
+  retry_on Aws::S3::Errors::ServiceError, wait: :polynomially_longer, attempts: 5
+  retry_on Errno::ECONNRESET,             wait: :polynomially_longer, attempts: 5
+  retry_on Net::OpenTimeout,              wait: :polynomially_longer, attempts: 5
+  retry_on Faraday::ConnectionFailed,     wait: :polynomially_longer, attempts: 5
+
+  # Discard if the object was deleted between enqueue and execution
+  discard_on ActiveFedora::ObjectNotFoundError
+
+  def perform(master_file_id)
+    Rails.logger.info "[S3Validation] Starting validation for MasterFile #{master_file_id}"
+
+    master_file = MasterFile.find(master_file_id)
+
+    mf_result    = validate_master_file(master_file)
+    deriv_results = validate_derivatives(master_file)
+
+    summary = build_summary(master_file_id, mf_result, deriv_results)
+    Rails.logger.info "[S3Validation] #{summary}"
+  end
+
+  private
+
+    # ── MasterFile validation ───────────────────────────────────────────
+
+    def validate_master_file(master_file)
+      file_location = master_file.file_location
+
+      if file_location.blank?
+        Rails.logger.info "[S3Validation] MasterFile #{master_file.id} has blank file_location, skipping"
+        return :skipped
+      end
+
+      # Only validate S3-based files (these are the ones that were migrated)
+      unless file_location.start_with?('s3://')
+        Rails.logger.info "[S3Validation] MasterFile #{master_file.id} is not on S3, skipping"
+        return :skipped
+      end
+
+      local_path = s3_uri_to_local_masterfile_path(file_location)
+
+      unless File.exist?(local_path)
+        Rails.logger.warn "[S3Validation] MasterFile #{master_file.id}: local file not found at #{truncate_path(local_path)}, skipping"
+        return :local_missing
+      end
+
+      validate_file(master_file.id, 'MasterFile', local_path, file_location)
+    end
+
+    # ── Derivative validation ───────────────────────────────────────────
+
+    def validate_derivatives(master_file)
+      master_file.derivatives.map do |derivative|
+        validate_derivative(derivative, master_file.id)
+      end
+    end
+
+    def validate_derivative(derivative, master_file_id)
+      deriv_location = derivative.derivativeFile
+
+      if deriv_location.blank?
+        Rails.logger.info "[S3Validation] Derivative #{derivative.id} has blank location, skipping"
+        return :skipped
+      end
+
+      unless deriv_location.start_with?('s3://')
+        Rails.logger.info "[S3Validation] Derivative #{derivative.id} is not on S3, skipping"
+        return :skipped
+      end
+
+      local_path = s3_uri_to_local_derivative_path(deriv_location)
+
+      unless File.exist?(local_path)
+        Rails.logger.warn "[S3Validation] Derivative #{derivative.id}: local file not found at #{truncate_path(local_path)}, skipping"
+        return :local_missing
+      end
+
+      validate_file(derivative.id, 'Derivative', local_path, deriv_location)
+    end
+
+    # ── Core validation logic ───────────────────────────────────────────
+
+    # Validates a single file: existence, size, and SHA-256 checksum.
+    # Returns :pass, :fail_missing, :fail_size, :fail_checksum, or :pass_size_only.
+    def validate_file(id, type, local_path, s3_uri)
+      s3_object = FileLocator::S3File.new(s3_uri).object
+
+      # 1. S3 object must exist
+      unless s3_object.exists?
+        Rails.logger.error "[S3Validation] FAIL #{type} #{id}: S3 object does not exist at #{truncate_path(s3_uri)}"
+        return :fail_missing
+      end
+
+      # 2. Size must match
+      local_size = File.size(local_path)
+      s3_size    = s3_object.content_length
+
+      unless local_size == s3_size
+        Rails.logger.error "[S3Validation] FAIL #{type} #{id}: size mismatch — local=#{local_size} s3=#{s3_size}"
+        return :fail_size
+      end
+
+      # 3. SHA-256 checksum comparison
+      s3_checksum = fetch_s3_sha256(s3_object)
+
+      if s3_checksum.nil?
+        Rails.logger.warn "[S3Validation] PASS (size only) #{type} #{id}: no SHA-256 stored on S3 object"
+        return :pass_size_only
+      end
+
+      local_checksum = compute_matching_local_checksum(local_path, s3_object, s3_checksum)
+
+      if local_checksum == s3_checksum
+        Rails.logger.info "[S3Validation] PASS #{type} #{id}: SHA-256 match (#{s3_checksum})"
+        :pass
+      else
+        Rails.logger.error "[S3Validation] FAIL #{type} #{id}: SHA-256 mismatch — local=#{local_checksum} s3=#{s3_checksum}"
+        :fail_checksum
+      end
+    end
+
+    # ── S3 checksum retrieval ───────────────────────────────────────────
+
+    # Fetch the SHA-256 checksum stored on the S3 object.
+    # Requires checksum_mode: 'ENABLED' to include additional checksums.
+    def fetch_s3_sha256(s3_object)
+      resp = s3_object.client.head_object(
+        bucket: s3_object.bucket_name,
+        key:    s3_object.key,
+        checksum_mode: 'ENABLED'
+      )
+      resp.checksum_sha256
+    rescue Aws::S3::Errors::ServiceError => e
+      Rails.logger.warn "[S3Validation] Could not fetch S3 checksum: #{e.message}"
+      nil
+    end
+
+    # ── Local checksum computation ──────────────────────────────────────
+
+    # Compute a local checksum that matches the S3 checksum format.
+    #
+    # For single-part uploads, S3 stores a plain base64-encoded SHA-256.
+    # For multipart uploads, the checksum is a composite:
+    #   Base64(SHA-256(part1_sha256 + part2_sha256 + ...))-N
+    # where N is the number of parts and each part_sha256 is the raw
+    # (binary) SHA-256 digest of that part's bytes.
+    #
+    # We detect multipart by the presence of a '-' suffix in the S3 checksum
+    # and use GetObjectAttributes to retrieve part sizes so we can compute
+    # the matching composite locally.
+    def compute_matching_local_checksum(local_path, s3_object, s3_checksum)
+      if s3_checksum.include?('-')
+        compute_local_multipart_sha256(local_path, s3_object, s3_checksum)
+      else
+        Digest::SHA256.file(local_path).base64digest
+      end
+    end
+
+    # Compute the composite SHA-256 that matches S3's multipart checksum.
+    #
+    # Steps:
+    #   1. Fetch part metadata (sizes) via GetObjectAttributes
+    #   2. Read the local file in matching chunks
+    #   3. SHA-256 each chunk
+    #   4. SHA-256 the concatenated raw digests
+    #   5. Base64-encode and append "-N"
+    def compute_local_multipart_sha256(local_path, s3_object, s3_checksum)
+      parts = fetch_object_parts(s3_object)
+
+      if parts.nil? || parts.empty?
+        Rails.logger.warn "[S3Validation] Could not retrieve multipart part info; falling back to size-only validation"
+        return nil
+      end
+
+      raw_digests = []
+
+      File.open(local_path, 'rb') do |f|
+        parts.each do |part|
+          chunk = f.read(part.size)
+          raw_digests << Digest::SHA256.digest(chunk)
+        end
+      end
+
+      composite_raw = Digest::SHA256.digest(raw_digests.join)
+      "#{Base64.strict_encode64(composite_raw)}-#{parts.size}"
+    end
+
+    # Retrieve part-level metadata for a multipart-uploaded S3 object.
+    def fetch_object_parts(s3_object)
+      resp = s3_object.client.get_object_attributes(
+        bucket: s3_object.bucket_name,
+        key:    s3_object.key,
+        object_attributes: ['ObjectParts']
+      )
+      resp.object_parts&.parts
+    rescue Aws::S3::Errors::ServiceError => e
+      Rails.logger.warn "[S3Validation] GetObjectAttributes failed: #{e.message}"
+      nil
+    end
+
+    # ── Reverse path mapping ────────────────────────────────────────────
+
+    # Reverse the S3 URI back to the original local masterfile path.
+    # s3://bucket/archive/2v/23/vt/36/id-file.mp4
+    #   -> /masterfiles/archive/2v/23/vt/36/id-file.mp4
+    def s3_uri_to_local_masterfile_path(s3_uri)
+      uri = Addressable::URI.parse(s3_uri)
+      key = Addressable::URI.unencode(uri.path).sub(%r{^/}, '')
+      File.join(masterfile_local_base, key)
+    end
+
+    # Reverse the S3 URI back to the original local derivative path.
+    # s3://bucket/uuid/outputs/name-high.mp4
+    #   -> /streamfiles/uuid/outputs/name-high.mp4
+    def s3_uri_to_local_derivative_path(s3_uri)
+      uri = Addressable::URI.parse(s3_uri)
+      key = Addressable::URI.unencode(uri.path).sub(%r{^/}, '')
+      File.join(derivative_local_base, key)
+    end
+
+    # ── Path helpers (shared with MigrateToS3Job) ───────────────────────
+
+    def masterfile_local_base
+      ENV.fetch('MIGRATE_MASTERFILE_LOCAL_BASE', '/masterfiles')
+    end
+
+    def derivative_local_base
+      ENV.fetch('MIGRATE_DERIVATIVE_LOCAL_BASE',
+                 ENV.fetch('LOCAL_DERIVATIVES_DIR', '/streamfiles'))
+    end
+
+    def truncate_path(path, max: 80)
+      path.length > max ? "#{path[0..40]}...#{path[-35..]}" : path
+    end
+
+    # ── Summary ─────────────────────────────────────────────────────────
+
+    def build_summary(master_file_id, mf_result, deriv_results)
+      all_results = [mf_result] + deriv_results
+      passes     = all_results.count { |r| r == :pass }
+      size_only  = all_results.count { |r| r == :pass_size_only }
+      skipped    = all_results.count { |r| r == :skipped || r == :local_missing }
+      failures   = all_results.count { |r| r.to_s.start_with?('fail') }
+
+      status = failures > 0 ? 'FAIL' : 'PASS'
+      "#{status} MasterFile #{master_file_id}: #{passes} passed, #{size_only} size-only, #{skipped} skipped, #{failures} failed"
+    end
+end
+# End UMD Customization

--- a/app/jobs/validate_s3_migration_job.rb
+++ b/app/jobs/validate_s3_migration_job.rb
@@ -183,44 +183,51 @@ class ValidateS3MigrationJob < ActiveJob::Base
 
     # Compute the composite SHA-256 that matches S3's multipart checksum.
     #
+    # For multipart uploads, S3 stores a composite checksum:
+    #   Base64(SHA-256(part1_sha256 + part2_sha256 + ...))-N
+    # where N is the number of parts.
+    #
+    # Instead of fetching part sizes from S3 (which requires the
+    # s3:GetObjectAttributes permission), we compute the part size
+    # using the same formula the AWS SDK uses by default:
+    #   part_size = max(ceil(file_size / 10_000), 5 MB)
+    #
     # Steps:
-    #   1. Fetch part metadata (sizes) via GetObjectAttributes
-    #   2. Read the local file in matching chunks
-    #   3. SHA-256 each chunk
-    #   4. SHA-256 the concatenated raw digests
-    #   5. Base64-encode and append "-N"
-    def compute_local_multipart_sha256(local_path, s3_object, s3_checksum)
-      parts = fetch_object_parts(s3_object)
-
-      if parts.nil? || parts.empty?
-        Rails.logger.warn "[S3Validation] Could not retrieve multipart part info; falling back to size-only validation"
-        return nil
-      end
+    #   1. Derive the number of parts from the S3 checksum suffix
+    #   2. Compute the default SDK part size from the local file size
+    #   3. Read the local file in matching chunks
+    #   4. SHA-256 each chunk
+    #   5. SHA-256 the concatenated raw digests
+    #   6. Base64-encode and append "-N"
+    def compute_local_multipart_sha256(local_path, _s3_object, s3_checksum)
+      num_parts = s3_checksum.split('-').last.to_i
+      file_size = File.size(local_path)
+      part_size = default_multipart_part_size(file_size)
 
       raw_digests = []
 
       File.open(local_path, 'rb') do |f|
-        parts.each do |part|
-          chunk = f.read(part.size)
+        num_parts.times do
+          chunk = f.read(part_size)
+          break if chunk.nil?
           raw_digests << Digest::SHA256.digest(chunk)
         end
       end
 
       composite_raw = Digest::SHA256.digest(raw_digests.join)
-      "#{Base64.strict_encode64(composite_raw)}-#{parts.size}"
+      "#{Base64.strict_encode64(composite_raw)}-#{raw_digests.size}"
     end
 
-    # Retrieve part-level metadata for a multipart-uploaded S3 object.
-    def fetch_object_parts(s3_object)
-      resp = s3_object.client.get_object_attributes(
-        bucket: s3_object.bucket_name,
-        key:    s3_object.key,
-        object_attributes: ['ObjectParts']
-      )
-      resp.object_parts&.parts
-    rescue Aws::S3::Errors::ServiceError => e
-      Rails.logger.warn "[S3Validation] GetObjectAttributes failed: #{e.message}"
-      nil
+    # Part size for multipart checksum validation. Must match the part size
+    # used during upload (S3_MIGRATION_PART_SIZE_MB). Separate env var so
+    # environments where migration already completed with a different part
+    # size can set validation independently.
+    #   part_size = max(ceil(file_size / 10_000), VALIDATION_PART_SIZE)
+    SDK_MAX_PARTS = 10_000
+    VALIDATION_PART_SIZE = (ENV.fetch('S3_VALIDATION_PART_SIZE_MB', '64').to_i * 1024 * 1024)
+
+    def default_multipart_part_size(file_size)
+      [(file_size.to_f / SDK_MAX_PARTS).ceil, VALIDATION_PART_SIZE].max
     end
 
     # ── Reverse path mapping ────────────────────────────────────────────

--- a/app/services/s3_migration_logger.rb
+++ b/app/services/s3_migration_logger.rb
@@ -1,0 +1,214 @@
+# UMD Customization
+#
+# S3-based audit logger for S3 migration.
+#
+# Each MasterFile and its Derivatives are logged as a single S3 object
+# containing multiple CSV rows (one for the MasterFile, one per Derivative),
+# keyed by the MasterFile ID. ActiveStorage blobs are logged as separate
+# individual objects.
+#
+# This avoids the need for a mounted volume and eliminates concurrency
+# issues — each MasterFile job writes to its own unique S3 key, so
+# multiple Sidekiq workers (even across pods) can write simultaneously.
+#
+# Entries are written to:
+#   s3://<bucket>/<prefix>/MasterFile-<master_file_id>.csv
+#   s3://<bucket>/<prefix>/ActiveStorage-blob-<blob_id>.csv
+#
+# The report rake task lists all objects under the prefix and merges them
+# into a single CSV.
+#
+# Configuration (environment variables):
+#   S3_MIGRATION_LOG_BUCKET  — S3 bucket (default: Settings.encoding.masterfile_bucket)
+#   S3_MIGRATION_LOG_PREFIX  — Key prefix (default: migration-audit)
+#
+# Usage:
+#   S3MigrationLogger.log_master_file_migration(
+#     master_file_id:  "abc123",
+#     media_object_id: "xyz789",
+#     master_file:     { source_path: "/local/file.mp4", destination_uri: "s3://bucket/file.mp4", ... },
+#     derivatives:     [{ resource_id: "def456", source_path: "...", destination_uri: "...", ... }]
+#   )
+#
+#   S3MigrationLogger.log_migration(
+#     resource_id: "blob-99", resource_type: "ActiveStorage", ...
+#   )
+#
+class S3MigrationLogger
+  HEADERS = %w[
+    resource_id resource_type media_object_id master_file_id source_path destination_uri
+    file_size checksum checksum_type status error_message migrated_at
+  ].freeze
+
+  class << self
+    # Log a MasterFile and all its Derivatives as a single audit record.
+    #
+    # @param master_file_id  [String] The MasterFile ID (used as the S3 key)
+    # @param media_object_id [String] The parent MediaObject ID
+    # @param master_file     [Hash]   { source_path:, destination_uri:, file_size:, checksum:, checksum_type: }
+    #                                 or nil if the MasterFile was skipped
+    # @param derivatives     [Array<Hash>] each: { resource_id:, source_path:, destination_uri:, file_size:, checksum:, checksum_type: }
+    def log_master_file_migration(master_file_id:, media_object_id:, master_file: nil, derivatives: [])
+      rows = []
+      now = Time.current.iso8601
+
+      if master_file
+        rows << {
+          resource_id:     master_file_id,
+          resource_type:   'MasterFile',
+          media_object_id: media_object_id,
+          master_file_id:  master_file_id,
+          source_path:     master_file[:source_path],
+          destination_uri: master_file[:destination_uri],
+          file_size:       master_file[:file_size],
+          checksum:        master_file[:checksum],
+          checksum_type:   master_file[:checksum_type] || 'SHA256',
+          status:          'migrated',
+          error_message:   nil,
+          migrated_at:     now
+        }
+      end
+
+      derivatives.each do |d|
+        rows << {
+          resource_id:     d[:resource_id],
+          resource_type:   'Derivative',
+          media_object_id: media_object_id,
+          master_file_id:  master_file_id,
+          source_path:     d[:source_path],
+          destination_uri: d[:destination_uri],
+          file_size:       d[:file_size],
+          checksum:        d[:checksum],
+          checksum_type:   d[:checksum_type] || 'SHA256',
+          status:          'migrated',
+          error_message:   nil,
+          migrated_at:     now
+        }
+      end
+
+      write_entry("MasterFile-#{sanitize_id(master_file_id)}", rows) unless rows.empty?
+    end
+
+    # Log a single resource migration (used for ActiveStorage blobs).
+    def log_migration(resource_id:, resource_type:, source_path:, destination_uri:,
+                      file_size: nil, checksum: nil, checksum_type: nil,
+                      media_object_id: nil, master_file_id: nil)
+      row = {
+        resource_id:     resource_id,
+        resource_type:   resource_type,
+        media_object_id: media_object_id,
+        master_file_id:  master_file_id,
+        source_path:     source_path,
+        destination_uri: destination_uri,
+        file_size:       file_size,
+        checksum:        checksum,
+        checksum_type:   checksum_type,
+        status:          'migrated',
+        error_message:   nil,
+        migrated_at:     Time.current.iso8601
+      }
+      write_entry("#{resource_type}-#{sanitize_id(resource_id)}", [row])
+    end
+
+    # Log a failed migration.
+    def log_failure(resource_id:, resource_type:, source_path:, destination_uri:,
+                    error_message:, media_object_id: nil, master_file_id: nil)
+      row = {
+        resource_id:     resource_id,
+        resource_type:   resource_type,
+        media_object_id: media_object_id,
+        master_file_id:  master_file_id,
+        source_path:     source_path,
+        destination_uri: destination_uri,
+        file_size:       nil,
+        checksum:        nil,
+        checksum_type:   nil,
+        status:          'failed',
+        error_message:   error_message,
+        migrated_at:     Time.current.iso8601
+      }
+      write_entry("#{resource_type}-#{sanitize_id(resource_id)}", [row])
+    end
+
+    # S3 bucket for audit log entries.
+    def log_bucket
+      ENV.fetch('S3_MIGRATION_LOG_BUCKET', Settings.encoding.masterfile_bucket)
+    end
+
+    # S3 key prefix for audit log entries.
+    def log_prefix
+      ENV.fetch('S3_MIGRATION_LOG_PREFIX', 'migration-audit')
+    end
+
+    # S3 URI of the audit log prefix (for display).
+    def log_path
+      "s3://#{log_bucket}/#{log_prefix}/"
+    end
+
+    # Download all audit entries from S3 and write a merged CSV to +output_path+.
+    # Returns the number of entries written.
+    def export_csv(output_path)
+      require 'csv'
+
+      entries = list_entries
+      CSV.open(output_path, 'w') do |csv|
+        csv << HEADERS
+        entries.each { |row| csv << row }
+      end
+      entries.size
+    end
+
+    # List all audit entries from S3 as arrays of field values.
+    # Each S3 object may contain one or more CSV rows.
+    def list_entries
+      require 'csv'
+
+      entries = []
+      s3_client.list_objects_v2(bucket: log_bucket, prefix: "#{log_prefix}/").each do |page|
+        page.contents.each do |obj|
+          next if obj.key == "#{log_prefix}/" # skip the "directory" marker
+
+          body = s3_client.get_object(bucket: log_bucket, key: obj.key).body.read
+          CSV.parse(body).each { |row| entries << row }
+        end
+      end
+      entries
+    end
+
+    # Count of audit S3 objects (each may contain multiple rows).
+    def count
+      total = 0
+      s3_client.list_objects_v2(bucket: log_bucket, prefix: "#{log_prefix}/").each do |page|
+        total += page.contents.count { |obj| obj.key != "#{log_prefix}/" }
+      end
+      total
+    end
+
+    private
+
+    # Write one or more CSV rows as a single S3 object.
+    # Key: <prefix>/<name>.csv
+    # Idempotent — retried jobs overwrite the same key.
+    def write_entry(name, rows)
+      require 'csv'
+
+      body = rows.map { |row| CSV.generate_line(HEADERS.map { |h| row[h.to_sym] }) }.join
+      s3_client.put_object(
+        bucket: log_bucket,
+        key:    "#{log_prefix}/#{name}.csv",
+        body:   body,
+        content_type: 'text/csv'
+      )
+    end
+
+    def s3_client
+      @s3_client ||= Aws::S3::Client.new
+    end
+
+    # Sanitize resource IDs for use in S3 keys (replace / with _).
+    def sanitize_id(id)
+      id.to_s.gsub('/', '_')
+    end
+  end
+end
+# End UMD Customization

--- a/app/services/s3_migration_logger.rb
+++ b/app/services/s3_migration_logger.rb
@@ -45,14 +45,19 @@ class S3MigrationLogger
     #
     # @param master_file_id  [String] The MasterFile ID (used as the S3 key)
     # @param media_object_id [String] The parent MediaObject ID
-    # @param master_file     [Hash]   { source_path:, destination_uri:, file_size:, checksum:, checksum_type: }
-    #                                 or nil if the MasterFile was skipped
+    # @param master_file     [Hash]   { source_path:, destination_uri:, file_size:, checksum:, checksum_type:, status: }
+    #                                 or nil if the MasterFile was skipped.
+    #                                 status defaults to 'migrated'. Use 'partial' when the source
+    #                                 file is missing but derivatives were migrated.
     # @param derivatives     [Array<Hash>] each: { resource_id:, source_path:, destination_uri:, file_size:, checksum:, checksum_type: }
     def log_master_file_migration(master_file_id:, media_object_id:, master_file: nil, derivatives: [])
       rows = []
       now = Time.current.iso8601
 
       if master_file
+        mf_status = master_file[:status] || 'migrated'
+        error_msg = mf_status == 'partial' ? 'Source file missing on local filesystem' : nil
+
         rows << {
           resource_id:     master_file_id,
           resource_type:   'MasterFile',
@@ -63,8 +68,8 @@ class S3MigrationLogger
           file_size:       master_file[:file_size],
           checksum:        master_file[:checksum],
           checksum_type:   master_file[:checksum_type] || 'SHA256',
-          status:          'migrated',
-          error_message:   nil,
+          status:          mf_status,
+          error_message:   error_msg,
           migrated_at:     now
         }
       end

--- a/lib/tasks/migrate_to_s3.rake
+++ b/lib/tasks/migrate_to_s3.rake
@@ -1,0 +1,191 @@
+# UMD Customization
+#
+# Rake tasks for migrating Avalon content from local filesystem to S3.
+#
+# Workflow:
+#   1. rake avalon:migrate:s3_migration_status          # Check current state
+#   2. rake avalon:migrate:enqueue_s3_migration          # Enqueue MasterFile+Derivative jobs
+#   3. rake avalon:migrate:active_storage_to_s3          # Migrate SupplementalFile blobs
+#   4. rake avalon:migrate:s3_migration_status          # Monitor progress
+#
+# All tasks are idempotent and safe to re-run.
+#
+namespace :avalon do
+  namespace :migrate do
+
+    # ── Enqueue MasterFile / Derivative migration ───────────────────────
+
+    desc "Enqueue S3 migration jobs for all filesystem-based MasterFiles"
+    task enqueue_s3_migration: :environment do
+      batch_size = ENV.fetch('BATCH_SIZE', '100').to_i
+      dry_run    = ENV.fetch('DRY_RUN', 'false').casecmp('true').zero?
+
+      # Find MasterFiles that have a file_location and it does NOT start with s3://
+      query = "has_model_ssim:MasterFile AND file_location_ssi:[* TO *] AND -file_location_ssi:s3\\:\\/\\/*"
+      start = 0
+      total_enqueued = 0
+
+      puts "Querying Solr for filesystem-based MasterFiles..."
+      puts "[DRY RUN] No jobs will be enqueued" if dry_run
+
+      loop do
+        response = ActiveFedora::SolrService.get(query, fl: 'id,file_location_ssi', rows: batch_size, start: start)
+        docs = response['response']['docs']
+        break if docs.empty?
+
+        docs.each do |doc|
+          next if doc['file_location_ssi'].blank?
+
+          master_file_id = doc['id']
+          if dry_run
+            puts "  [DRY RUN] Would enqueue: #{master_file_id} (#{doc['file_location_ssi']})"
+          else
+            MigrateToS3Job.perform_later(master_file_id)
+          end
+          total_enqueued += 1
+        end
+
+        start += batch_size
+        puts "  Processed #{start} records..." if (start % 500).zero?
+      end
+
+      puts "#{dry_run ? 'Would enqueue' : 'Enqueued'} #{total_enqueued} MasterFile(s) for S3 migration"
+    end
+
+    # ── ActiveStorage blob migration ────────────────────────────────────
+
+    desc "Migrate ActiveStorage blobs from local disk to S3"
+    task active_storage_to_s3: :environment do
+      dry_run             = ENV.fetch('DRY_RUN', 'false').casecmp('true').zero?
+      target_service_name = ENV.fetch('TARGET_SERVICE', 'amazon')
+
+      local_blobs = ActiveStorage::Blob.where(service_name: "local")
+      total = local_blobs.count
+
+      puts "Found #{total} ActiveStorage blob(s) on local disk"
+      puts "[DRY RUN] No blobs will be migrated" if dry_run
+      puts "Target service: #{target_service_name}"
+
+      if total.zero?
+        puts "Nothing to migrate."
+        next
+      end
+
+      target_service = ActiveStorage::Blob.services.fetch(target_service_name)
+
+      migrated = 0
+      errors   = 0
+
+      local_blobs.find_each do |blob|
+        if dry_run
+          puts "  [DRY RUN] Would migrate blob #{blob.id}: #{blob.filename} (#{blob.byte_size} bytes)"
+          migrated += 1
+          next
+        end
+
+        begin
+          # If the file already exists in the target (e.g. partial previous run),
+          # just update the service_name
+          if target_service.exist?(blob.key)
+            puts "  Blob #{blob.id} already exists in #{target_service_name}, updating record"
+            blob.update_column(:service_name, target_service_name)
+            migrated += 1
+            next
+          end
+
+          # Download from local disk service and upload to S3
+          blob.open do |tempfile|
+            target_service.upload(blob.key, tempfile, checksum: blob.checksum)
+          end
+
+          # Verify
+          unless target_service.exist?(blob.key)
+            raise "Upload verification failed for blob #{blob.id}"
+          end
+
+          blob.update_column(:service_name, target_service_name)
+          migrated += 1
+          puts "  Migrated blob #{blob.id}: #{blob.filename}"
+        rescue => e
+          errors += 1
+          puts "  ERROR migrating blob #{blob.id}: #{e.class} - #{e.message}"
+        end
+      end
+
+      puts ""
+      puts "ActiveStorage migration complete: #{migrated} migrated, #{errors} error(s) out of #{total} total"
+    end
+
+    # ── Status / progress reporting ─────────────────────────────────────
+
+    desc "Show S3 migration progress for MasterFiles, Derivatives, and ActiveStorage"
+    task s3_migration_status: :environment do
+      puts "=== S3 Migration Status ==="
+      puts ""
+
+      # ── MasterFiles ──
+      mf_total_q = "has_model_ssim:MasterFile AND file_location_ssi:[* TO *]"
+      mf_s3_q    = "has_model_ssim:MasterFile AND file_location_ssi:s3\\:\\/\\/*"
+      mf_local_q = "has_model_ssim:MasterFile AND file_location_ssi:[* TO *] AND -file_location_ssi:s3\\:\\/\\/*"
+
+      mf_total = solr_count(mf_total_q)
+      mf_s3    = solr_count(mf_s3_q)
+      mf_local = solr_count(mf_local_q)
+
+      puts "MasterFiles (with file_location): #{mf_total}"
+      puts "  On S3:           #{mf_s3}"
+      puts "  On filesystem:   #{mf_local}"
+      if mf_total > 0
+        puts "  Progress:        #{percentage(mf_s3, mf_total)}%"
+      end
+      puts ""
+
+      # ── Derivatives ──
+      d_total_q = "has_model_ssim:Derivative AND derivativeFile_ssi:[* TO *]"
+      d_s3_q    = "has_model_ssim:Derivative AND derivativeFile_ssi:s3\\:\\/\\/*"
+      d_local_q = "has_model_ssim:Derivative AND derivativeFile_ssi:file\\:\\/\\/*"
+
+      d_total = solr_count(d_total_q)
+      d_s3    = solr_count(d_s3_q)
+      d_local = solr_count(d_local_q)
+
+      puts "Derivatives (with derivativeFile): #{d_total}"
+      puts "  On S3:           #{d_s3}"
+      puts "  On filesystem:   #{d_local}"
+      if d_total > 0
+        puts "  Progress:        #{percentage(d_s3, d_total)}%"
+      end
+      puts ""
+
+      # ── ActiveStorage blobs ──
+      if defined?(ActiveStorage::Blob)
+        as_total = ActiveStorage::Blob.count
+        as_local = ActiveStorage::Blob.where(service_name: "local").count
+        as_s3    = as_total - as_local
+
+        puts "ActiveStorage Blobs: #{as_total}"
+        puts "  On S3:           #{as_s3}"
+        puts "  On local disk:   #{as_local}"
+        if as_total > 0
+          puts "  Progress:        #{percentage(as_s3, as_total)}%"
+        end
+        puts ""
+      end
+
+      puts "==========================="
+    end
+
+    # ── Helpers ─────────────────────────────────────────────────────────
+
+    def solr_count(query)
+      ActiveFedora::SolrService.get(query, rows: 0)['response']['numFound']
+    end
+
+    def percentage(numerator, denominator)
+      return 0.0 if denominator.zero?
+      (numerator.to_f / denominator * 100).round(1)
+    end
+
+  end
+end
+# End UMD Customization

--- a/lib/tasks/migrate_to_s3.rake
+++ b/lib/tasks/migrate_to_s3.rake
@@ -599,10 +599,12 @@ namespace :avalon do
                 # absolute_location= triggers set_streaming_locations! which
                 # recalculates location_url and hls_url based on current config.
                 # Since config targets S3 (/s3-avalon/streamfiles), we must fix
-                # the URLs to use the filesystem streaming path (/avalon).
+                # the URLs to use the filesystem streaming path (/avalon). Also,
+                # recompute location_url to be relative to derivative_base.
                 derivative.absolute_location = file_uri
                 derivative.hls_url = derivative.hls_url&.gsub('/s3-avalon/streamfiles', '/avalon')
-                derivative.location_url = derivative.location_url&.gsub('/s3-avalon/streamfiles', '/avalon')
+                rel = Pathname.new(d_local_path).relative_path_from(Pathname.new(derivative_base))
+                derivative.location_url = "#{rel.dirname}/#{rel.basename(rel.extname)}"
                 derivative.save!
                 d_reverted += 1
                 puts "    Reverted Derivative #{derivative.id}"

--- a/lib/tasks/migrate_to_s3.rake
+++ b/lib/tasks/migrate_to_s3.rake
@@ -160,7 +160,7 @@ namespace :avalon do
 
       # Find MasterFiles whose file_location starts with s3://
       # These are the ones that have been migrated.
-      query = "has_model_ssim:MasterFile AND file_location_ssi:s3\\:\\/\\/*"
+      query = "has_model_ssim:MasterFile AND file_location_ssi:[* TO *]"
 
       # Optional: restrict to items ingested before a cutoff date.
       # Items ingested before this date were originally on the local filesystem.

--- a/lib/tasks/migrate_to_s3.rake
+++ b/lib/tasks/migrate_to_s3.rake
@@ -212,6 +212,7 @@ namespace :avalon do
       d_count  = rows.count { |r| r['resource_type'] == 'Derivative' }
       as_count = rows.count { |r| r['resource_type'] == 'ActiveStorage' }
       migrated = rows.count { |r| r['status'] == 'migrated' }
+      partial  = rows.count { |r| r['status'] == 'partial' }
       failed   = rows.count { |r| r['status'] == 'failed' }
 
       puts "Total entries:    #{total}"
@@ -220,8 +221,18 @@ namespace :avalon do
       puts "  ActiveStorage:  #{as_count}"
       puts ""
       puts "  Migrated:       #{migrated}"
+      puts "  Partial:        #{partial}" if partial > 0
       puts "  Failed:         #{failed}" if failed > 0
       puts ""
+
+      if partial > 0
+        puts "Partial migrations (MasterFile source missing, derivatives migrated):"
+        rows.select { |r| r['status'] == 'partial' }.each do |r|
+          mo_id = r['media_object_id'].presence || 'unknown'
+          puts "  MasterFile #{r['resource_id']} (MediaObject: #{mo_id}): #{r['source_path']}"
+        end
+        puts ""
+      end
 
       if failed > 0
         puts "Failed entries:"

--- a/lib/tasks/migrate_to_s3.rake
+++ b/lib/tasks/migrate_to_s3.rake
@@ -8,6 +8,13 @@
 #   3. rake avalon:migrate:active_storage_to_s3          # Migrate SupplementalFile blobs
 #   4. rake avalon:migrate:s3_migration_status          # Monitor progress
 #   5. rake avalon:migrate:enqueue_s3_validation         # Post-migration checksum validation
+ #   6. rake avalon:migrate:s3_migration_report           # View audit trail summary
+#   7. rake avalon:migrate:validate_active_storage       # Validate ActiveStorage blobs on S3
+#
+# An audit trail is written automatically to S3 during steps 2 and 3.
+# Each entry is stored as an individual S3 object under a configurable prefix:
+#   S3_MIGRATION_LOG_BUCKET  (default: Settings.encoding.masterfile_bucket)
+#   S3_MIGRATION_LOG_PREFIX  (default: migration-audit)
 #
 # All tasks are idempotent and safe to re-run.
 #
@@ -59,6 +66,8 @@ namespace :avalon do
     task active_storage_to_s3: :environment do
       dry_run             = ENV.fetch('DRY_RUN', 'false').casecmp('true').zero?
       target_service_name = ENV.fetch('TARGET_SERVICE', 'amazon')
+      local_root          = ENV.fetch('ACTIVE_STORAGE_LOCAL_ROOT',
+                              Settings.active_storage&.root || '/masterfiles/supplemental_files/rails_active_storage')
 
       local_blobs = ActiveStorage::Blob.where(service_name: "local")
       total = local_blobs.count
@@ -90,6 +99,7 @@ namespace :avalon do
           if target_service.exist?(blob.key)
             puts "  Blob #{blob.id} already exists in #{target_service_name}, updating record"
             blob.update_column(:service_name, target_service_name)
+            log_active_storage_migration(blob, local_root, target_service_name)
             migrated += 1
             next
           end
@@ -107,9 +117,15 @@ namespace :avalon do
           blob.update_column(:service_name, target_service_name)
           migrated += 1
           puts "  Migrated blob #{blob.id}: #{blob.filename}"
+
+          # Audit trail
+          log_active_storage_migration(blob, local_root, target_service_name)
         rescue => e
           errors += 1
           puts "  ERROR migrating blob #{blob.id}: #{e.class} - #{e.message}"
+
+          # Log failure
+          log_active_storage_failure(blob, local_root, target_service_name, e)
         end
       end
 
@@ -163,6 +179,137 @@ namespace :avalon do
       end
 
       puts "#{dry_run ? 'Would enqueue' : 'Enqueued'} #{total_enqueued} MasterFile(s) for S3 validation"
+    end
+
+    # ── Migration report (from S3 audit trail) ─────────────────────────
+
+    desc "Display a summary of the S3 migration audit trail and optionally export to CSV"
+    task s3_migration_report: :environment do
+      require 'csv'
+
+      puts "=== S3 Migration Audit Trail ==="
+      puts "Source: #{S3MigrationLogger.log_path}"
+      puts ""
+
+      puts "Fetching audit entries from S3..."
+      entries = S3MigrationLogger.list_entries
+      total = entries.length
+
+      if total.zero?
+        puts "No audit entries found. Run the migration first."
+        puts ""
+        puts "Audit entries are written automatically to:"
+        puts "  Bucket: #{S3MigrationLogger.log_bucket}"
+        puts "  Prefix: #{S3MigrationLogger.log_prefix}/"
+        next
+      end
+
+      # Parse entries into hashes for easy filtering
+      headers = S3MigrationLogger::HEADERS
+      rows = entries.map { |row| headers.zip(row).to_h }
+
+      mf_count = rows.count { |r| r['resource_type'] == 'MasterFile' }
+      d_count  = rows.count { |r| r['resource_type'] == 'Derivative' }
+      as_count = rows.count { |r| r['resource_type'] == 'ActiveStorage' }
+      migrated = rows.count { |r| r['status'] == 'migrated' }
+      failed   = rows.count { |r| r['status'] == 'failed' }
+
+      puts "Total entries:    #{total}"
+      puts "  MasterFiles:    #{mf_count}"
+      puts "  Derivatives:    #{d_count}"
+      puts "  ActiveStorage:  #{as_count}"
+      puts ""
+      puts "  Migrated:       #{migrated}"
+      puts "  Failed:         #{failed}" if failed > 0
+      puts ""
+
+      if failed > 0
+        puts "Failed entries:"
+        rows.select { |r| r['status'] == 'failed' }.each do |r|
+          puts "  #{r['resource_type']} #{r['resource_id']}: #{r['error_message']}"
+        end
+        puts ""
+      end
+
+      # Export to local CSV if REPORT_PATH is set
+      output_path = ENV['REPORT_PATH']
+      if output_path.present?
+        count = S3MigrationLogger.export_csv(output_path)
+        puts "Exported #{count} entries to #{output_path}"
+      else
+        puts "Set REPORT_PATH to export the audit trail to a local CSV file."
+      end
+
+      puts "==============================="
+    end
+
+    # ── Validate ActiveStorage blobs ────────────────────────────────────
+
+    desc "Validate ActiveStorage blobs migrated to S3 (checksum + size)"
+    task validate_active_storage: :environment do
+      dry_run = ENV.fetch('DRY_RUN', 'false').casecmp('true').zero?
+      target_service_name = ENV.fetch('TARGET_SERVICE', 'amazon')
+
+      s3_blobs = ActiveStorage::Blob.where(service_name: target_service_name)
+      total = s3_blobs.count
+
+      puts "Found #{total} ActiveStorage blob(s) on #{target_service_name}"
+
+      if total.zero?
+        puts "Nothing to validate."
+        next
+      end
+
+      target_service = ActiveStorage::Blob.services.fetch(target_service_name)
+
+      passed  = 0
+      failed  = 0
+      skipped = 0
+
+      s3_blobs.find_each do |blob|
+        # 1. Check existence on S3
+        unless target_service.exist?(blob.key)
+          puts "  FAIL blob #{blob.id} (#{blob.filename}): not found on S3"
+          failed += 1
+          next
+        end
+
+        # 2. Download and verify MD5 checksum
+        #    ActiveStorage stores base64-encoded MD5 in the checksum column.
+        begin
+          if dry_run
+            puts "  [DRY RUN] Would validate blob #{blob.id}: #{blob.filename} (#{blob.byte_size} bytes)"
+            skipped += 1
+            next
+          end
+
+          # Download from S3 into a tempfile and compute MD5
+          blob.open do |tempfile|
+            computed_md5 = Digest::MD5.file(tempfile.path).base64digest
+            file_size    = File.size(tempfile.path)
+
+            size_ok     = (file_size == blob.byte_size)
+            checksum_ok = (computed_md5 == blob.checksum)
+
+            if size_ok && checksum_ok
+              puts "  PASS blob #{blob.id} (#{blob.filename}): size=#{file_size}, md5=#{computed_md5}"
+              passed += 1
+            else
+              reasons = []
+              reasons << "size mismatch (expected=#{blob.byte_size}, got=#{file_size})" unless size_ok
+              reasons << "checksum mismatch (expected=#{blob.checksum}, got=#{computed_md5})" unless checksum_ok
+              puts "  FAIL blob #{blob.id} (#{blob.filename}): #{reasons.join(', ')}"
+              failed += 1
+            end
+          end
+        rescue => e
+          puts "  ERROR blob #{blob.id} (#{blob.filename}): #{e.class} - #{e.message}"
+          failed += 1
+        end
+      end
+
+      puts ""
+      puts "ActiveStorage validation complete: #{passed} passed, #{failed} failed, #{skipped} skipped out of #{total} total"
     end
 
     # ── Status / progress reporting ─────────────────────────────────────
@@ -233,6 +380,57 @@ namespace :avalon do
     def percentage(numerator, denominator)
       return 0.0 if denominator.zero?
       (numerator.to_f / denominator * 100).round(1)
+    end
+
+    # Look up the parent MediaObject ID for an ActiveStorage blob.
+    # SupplementalFile stores parent_id which is the MediaObject ID.
+    def media_object_id_for_blob(blob)
+      attachment = blob.attachments.first
+      return nil unless attachment
+      record = attachment.record
+      if record.respond_to?(:parent_id)
+        master_file = MasterFile.find(record.parent_id)
+        if master_file.present?
+          return master_file.media_object.id if master_file.media_object
+        else
+          record.parent_id
+        end
+      else
+        nil
+      end
+    rescue => e
+      puts "  WARNING: Failed to determine media_object_id for blob #{blob.id}: #{e.message}"
+      nil
+    end
+
+    # Log a successful ActiveStorage blob migration to the audit CSV.
+    def log_active_storage_migration(blob, local_root, target_service_name)
+      S3MigrationLogger.log_migration(
+        resource_id:     "blob-#{blob.id}",
+        resource_type:   'ActiveStorage',
+        media_object_id: media_object_id_for_blob(blob),
+        source_path:     File.join(local_root, blob.key),
+        destination_uri: "s3://#{Settings.active_storage&.bucket || target_service_name}/#{blob.key}",
+        file_size:       blob.byte_size,
+        checksum:        blob.checksum,
+        checksum_type:   'MD5'
+      )
+    rescue => e
+      puts "  WARNING: Failed to log audit entry for blob #{blob.id}: #{e.message}"
+    end
+
+    # Log a failed ActiveStorage blob migration to the audit CSV.
+    def log_active_storage_failure(blob, local_root, target_service_name, error)
+      S3MigrationLogger.log_failure(
+        resource_id:     "blob-#{blob.id}",
+        resource_type:   'ActiveStorage',
+        media_object_id: media_object_id_for_blob(blob),
+        source_path:     File.join(local_root, blob.key),
+        destination_uri: "s3://#{Settings.active_storage&.bucket || target_service_name}/#{blob.key}",
+        error_message:   "#{error.class}: #{error.message}"
+      )
+    rescue => e
+      puts "  WARNING: Failed to log audit failure for blob #{blob.id}: #{e.message}"
     end
 
   end

--- a/lib/tasks/migrate_to_s3.rake
+++ b/lib/tasks/migrate_to_s3.rake
@@ -316,7 +316,9 @@ namespace :avalon do
 
     desc "Show S3 migration progress for MasterFiles, Derivatives, and ActiveStorage"
     task s3_migration_status: :environment do
-      cutoff_date = ENV.fetch('S3_MIGRATION_CUTOFF_DATE', '')
+      cutoff_date       = ENV.fetch('S3_MIGRATION_CUTOFF_DATE', '')
+      check_local_files = ENV.fetch('CHECK_LOCAL_FILES', 'false').casecmp('true').zero?
+      batch_size        = ENV.fetch('BATCH_SIZE', '100').to_i
 
       puts "=== S3 Migration Status ==="
       if cutoff_date.present?
@@ -384,6 +386,155 @@ namespace :avalon do
         puts ""
       end
 
+      # ── Local file existence check ──
+      if check_local_files
+        puts "--- Local File Existence Check ---"
+        puts ""
+
+        # Check MasterFiles on filesystem
+        mf_missing = []
+        start = 0
+        mf_checked = 0
+
+        puts "Checking MasterFiles on filesystem..."
+        loop do
+          response = ActiveFedora::SolrService.get(mf_local_q,
+            fl: 'id,file_location_ssi,isPartOf_ssim', rows: batch_size, start: start)
+          docs = response['response']['docs']
+          break if docs.empty?
+
+          docs.each do |doc|
+            file_path = doc['file_location_ssi']
+            next if file_path.blank?
+            mf_checked += 1
+
+            unless File.exist?(file_path)
+              media_object_title = media_object_title_for_master_file(doc)
+              mf_missing << {
+                id: doc['id'],
+                path: file_path,
+                media_object_title: media_object_title
+              }
+            end
+          end
+
+          start += batch_size
+          puts "  Checked #{start} MasterFiles..." if (start % 500).zero?
+        end
+
+        puts "MasterFiles checked:  #{mf_checked}"
+        puts "  Missing locally:    #{mf_missing.size}"
+        if mf_checked > 0
+          puts "  Missing:            #{percentage(mf_missing.size, mf_checked)}%"
+        end
+
+        if mf_missing.any?
+          puts ""
+          puts "  Missing MasterFiles:"
+          mf_missing.each do |entry|
+            puts "    #{entry[:id]} | #{entry[:media_object_title]} | #{entry[:path]}"
+          end
+        end
+        puts ""
+
+        # Check Derivatives on filesystem
+        d_missing = []
+        start = 0
+        d_checked = 0
+
+        puts "Checking Derivatives on filesystem..."
+        loop do
+          response = ActiveFedora::SolrService.get(d_local_q,
+            fl: 'id,derivativeFile_ssi,isDerivationOf_ssim', rows: batch_size, start: start)
+          docs = response['response']['docs']
+          break if docs.empty?
+
+          docs.each do |doc|
+            deriv_uri = doc['derivativeFile_ssi']
+            next if deriv_uri.blank?
+            d_checked += 1
+
+            begin
+              local_path = Addressable::URI.parse(deriv_uri).path
+            rescue
+              local_path = deriv_uri.sub(%r{^file://}, '')
+            end
+
+            unless File.exist?(local_path)
+              media_object_title = media_object_title_for_derivative(doc)
+              d_missing << {
+                id: doc['id'],
+                path: local_path,
+                media_object_title: media_object_title
+              }
+            end
+          end
+
+          start += batch_size
+          puts "  Checked #{start} Derivatives..." if (start % 500).zero?
+        end
+
+        puts "Derivatives checked:  #{d_checked}"
+        puts "  Missing locally:    #{d_missing.size}"
+        if d_checked > 0
+          puts "  Missing:            #{percentage(d_missing.size, d_checked)}%"
+        end
+
+        if d_missing.any?
+          puts ""
+          puts "  Missing Derivatives:"
+          d_missing.each do |entry|
+            puts "    #{entry[:id]} | #{entry[:media_object_title]} | #{entry[:path]}"
+          end
+        end
+        puts ""
+
+        # Check ActiveStorage blobs on local disk
+        if defined?(ActiveStorage::Blob)
+          as_scope = ActiveStorage::Blob.where(service_name: "local")
+          as_scope = as_scope.where("created_at < ?", cutoff_time) if cutoff_time
+
+          local_root = ENV.fetch('ACTIVE_STORAGE_LOCAL_ROOT',
+                        Settings.active_storage&.root || '/masterfiles/supplemental_files/rails_active_storage')
+
+          as_missing = []
+          as_checked = 0
+
+          puts "Checking ActiveStorage blobs on local disk..."
+          as_scope.find_each do |blob|
+            as_checked += 1
+            blob_path = File.join(local_root, blob.key)
+
+            unless File.exist?(blob_path)
+              title = media_object_title_for_blob(blob)
+              as_missing << {
+                id: "blob-#{blob.id}",
+                filename: blob.filename.to_s,
+                path: blob_path,
+                media_object_title: title
+              }
+            end
+          end
+
+          puts "ActiveStorage blobs checked: #{as_checked}"
+          puts "  Missing locally:           #{as_missing.size}"
+          if as_checked > 0
+            puts "  Missing:                   #{percentage(as_missing.size, as_checked)}%"
+          end
+
+          if as_missing.any?
+            puts ""
+            puts "  Missing ActiveStorage blobs:"
+            as_missing.each do |entry|
+              puts "    #{entry[:id]} | #{entry[:media_object_title]} | #{entry[:filename]} | #{entry[:path]}"
+            end
+          end
+          puts ""
+        end
+
+        puts "--- End Local File Check ---"
+      end
+
       puts "==========================="
     end
 
@@ -396,6 +547,62 @@ namespace :avalon do
     def percentage(numerator, denominator)
       return 0.0 if denominator.zero?
       (numerator.to_f / denominator * 100).round(1)
+    end
+
+    # Look up the parent MediaObject title from a MasterFile Solr doc.
+    # MasterFile → isPartOf_ssim → MediaObject ID → title_tesi
+    def media_object_title_for_master_file(solr_doc)
+      media_object_ids = solr_doc['isPartOf_ssim']
+      return 'Orphan item' if media_object_ids.blank?
+
+      mo_id = media_object_ids.first
+      mo_response = ActiveFedora::SolrService.get(
+        "id:\"#{mo_id}\"", fl: 'title_tesi', rows: 1
+      )
+      mo_doc = mo_response['response']['docs'].first
+      return 'Orphan item' if mo_doc.nil?
+
+      mo_doc['title_tesi'].presence || 'Untitled'
+    rescue => e
+      "Error: #{e.message}"
+    end
+
+    # Look up the parent MediaObject title from a Derivative Solr doc.
+    # Derivative → isDerivationOf_ssim → MasterFile → isPartOf_ssim → MediaObject
+    def media_object_title_for_derivative(solr_doc)
+      master_file_ids = solr_doc['isDerivationOf_ssim']
+      return 'Orphan item' if master_file_ids.blank?
+
+      mf_id = master_file_ids.first
+      mf_response = ActiveFedora::SolrService.get(
+        "id:\"#{mf_id}\"", fl: 'isPartOf_ssim', rows: 1
+      )
+      mf_doc = mf_response['response']['docs'].first
+      return 'Orphan item' if mf_doc.nil?
+
+      media_object_title_for_master_file(mf_doc)
+    rescue => e
+      "Error: #{e.message}"
+    end
+
+    # Look up the parent MediaObject title from an ActiveStorage blob.
+    # Blob → attachment → SupplementalFile → parent_id → MediaObject
+    def media_object_title_for_blob(blob)
+      attachment = blob.attachments.first
+      return 'Orphan item' unless attachment
+
+      record = attachment.record
+      return 'Orphan item' unless record.respond_to?(:parent_id) && record.parent_id.present?
+
+      mo_response = ActiveFedora::SolrService.get(
+        "id:\"#{record.parent_id}\"", fl: 'title_tesi', rows: 1
+      )
+      mo_doc = mo_response['response']['docs'].first
+      return 'Orphan item' if mo_doc.nil?
+
+      mo_doc['title_tesi'].presence || 'Untitled'
+    rescue => e
+      "Error: #{e.message}"
     end
 
     # Look up the parent MediaObject ID for an ActiveStorage blob.

--- a/lib/tasks/migrate_to_s3.rake
+++ b/lib/tasks/migrate_to_s3.rake
@@ -156,7 +156,7 @@ namespace :avalon do
       dry_run      = ENV.fetch('DRY_RUN', 'false').casecmp('true').zero?
       filter_query = ENV.fetch('S3_MIGRATION_FILTER_QUERY', '')
       collection   = ENV.fetch('S3_MIGRATION_COLLECTION', '')
-      S3_MIGRATION_CUTOFF_DATE = ENV.fetch('S3_MIGRATION_CUTOFF_DATE', '')
+      cutoff_date = ENV.fetch('S3_MIGRATION_CUTOFF_DATE', '')
 
       # Find MasterFiles whose file_location starts with s3://
       # These are the ones that have been migrated.
@@ -164,10 +164,10 @@ namespace :avalon do
 
       # Optional: restrict to items ingested before a cutoff date.
       # Items ingested before this date were originally on the local filesystem.
-      # Format: ISO 8601, e.g. S3_MIGRATION_CUTOFF_DATE=2026-02-01T00:00:00Z
-      if S3_MIGRATION_CUTOFF_DATE.present?
-        query += " AND system_create_dtsi:[* TO #{S3_MIGRATION_CUTOFF_DATE}]"
-        puts "Filtering to items created before #{S3_MIGRATION_CUTOFF_DATE}"
+      # Format: ISO 8601, e.g. cutoff_date=2026-02-01T00:00:00Z
+      if cutoff_date.present?
+        query += " AND system_create_dtsi:[* TO #{cutoff_date}]"
+        puts "Filtering to items created before #{cutoff_date}"
       end
 
       query += " AND #{filter_query}" if filter_query.present?

--- a/lib/tasks/migrate_to_s3.rake
+++ b/lib/tasks/migrate_to_s3.rake
@@ -123,7 +123,7 @@ namespace :avalon do
     task enqueue_s3_validation: :environment do
       batch_size  = ENV.fetch('BATCH_SIZE', '100').to_i
       dry_run     = ENV.fetch('DRY_RUN', 'false').casecmp('true').zero?
-      cutoff_date = ENV.fetch('CUTOFF_DATE', '')
+      S3_MIGRATION_CUTOFF_DATE = ENV.fetch('S3_MIGRATION_CUTOFF_DATE', '')
 
       # Find MasterFiles whose file_location starts with s3://
       # These are the ones that have been migrated.
@@ -131,10 +131,10 @@ namespace :avalon do
 
       # Optional: restrict to items ingested before a cutoff date.
       # Items ingested before this date were originally on the local filesystem.
-      # Format: ISO 8601, e.g. CUTOFF_DATE=2026-02-01T00:00:00Z
-      if cutoff_date.present?
-        query += " AND date_digitized_dtsi:[* TO #{cutoff_date}]"
-        puts "Filtering to items digitized before #{cutoff_date}"
+      # Format: ISO 8601, e.g. S3_MIGRATION_CUTOFF_DATE=2026-02-01T00:00:00Z
+      if S3_MIGRATION_CUTOFF_DATE.present?
+        query += " AND system_create_dtsi:[* TO #{S3_MIGRATION_CUTOFF_DATE}]"
+        puts "Filtering to items created before #{S3_MIGRATION_CUTOFF_DATE}"
       end
 
       start = 0

--- a/lib/tasks/migrate_to_s3.rake
+++ b/lib/tasks/migrate_to_s3.rake
@@ -27,20 +27,28 @@ namespace :avalon do
     task enqueue_s3_migration: :environment do
       batch_size    = ENV.fetch('BATCH_SIZE', '100').to_i
       dry_run       = ENV.fetch('DRY_RUN', 'false').casecmp('true').zero?
-      filter_query  = ENV.fetch('SOLR_FILTER_QUERY', '')
+      filter_query  = ENV.fetch('S3_MIGRATION_FILTER_QUERY', '')
+      collection    = ENV.fetch('S3_MIGRATION_COLLECTION', '')
 
       # Find MasterFiles that have a file_location and it does NOT start with s3://
       query = "has_model_ssim:MasterFile AND file_location_ssi:[* TO *] AND -file_location_ssi:s3\\:\\/\\/*"
       query += " AND #{filter_query}" if filter_query.present?
+
+      # Collection filter uses Solr join — must be passed as fq, not in q
+      solr_fq = collection.present? ? media_object_join_clause(collection) : nil
+
       start = 0
       total_enqueued = 0
 
       puts "Querying Solr for filesystem-based MasterFiles..."
       puts "Filter query: #{filter_query}" if filter_query.present?
+      puts "Collection: #{collection}" if collection.present?
       puts "[DRY RUN] No jobs will be enqueued" if dry_run
 
       loop do
-        response = ActiveFedora::SolrService.get(query, fl: 'id,file_location_ssi', rows: batch_size, start: start)
+        solr_params = { fl: 'id,file_location_ssi', rows: batch_size, start: start }
+        solr_params[:fq] = solr_fq if solr_fq
+        response = ActiveFedora::SolrService.get(query, solr_params)
         docs = response['response']['docs']
         break if docs.empty?
 
@@ -142,7 +150,8 @@ namespace :avalon do
     task enqueue_s3_validation: :environment do
       batch_size   = ENV.fetch('BATCH_SIZE', '100').to_i
       dry_run      = ENV.fetch('DRY_RUN', 'false').casecmp('true').zero?
-      filter_query = ENV.fetch('SOLR_FILTER_QUERY', '')
+      filter_query = ENV.fetch('S3_MIGRATION_FILTER_QUERY', '')
+      collection   = ENV.fetch('S3_MIGRATION_COLLECTION', '')
       S3_MIGRATION_CUTOFF_DATE = ENV.fetch('S3_MIGRATION_CUTOFF_DATE', '')
 
       # Find MasterFiles whose file_location starts with s3://
@@ -159,15 +168,21 @@ namespace :avalon do
 
       query += " AND #{filter_query}" if filter_query.present?
 
+      # Collection filter uses Solr join — must be passed as fq, not in q
+      solr_fq = collection.present? ? media_object_join_clause(collection) : nil
+
       start = 0
       total_enqueued = 0
 
       puts "Querying Solr for migrated (S3-based) MasterFiles..."
       puts "Filter query: #{filter_query}" if filter_query.present?
+      puts "Collection: #{collection}" if collection.present?
       puts "[DRY RUN] No jobs will be enqueued" if dry_run
 
       loop do
-        response = ActiveFedora::SolrService.get(query, fl: 'id,file_location_ssi', rows: batch_size, start: start)
+        solr_params = { fl: 'id,file_location_ssi', rows: batch_size, start: start }
+        solr_params[:fq] = solr_fq if solr_fq
+        response = ActiveFedora::SolrService.get(query, solr_params)
         docs = response['response']['docs']
         break if docs.empty?
 
@@ -343,6 +358,8 @@ namespace :avalon do
       cutoff_date       = ENV.fetch('S3_MIGRATION_CUTOFF_DATE', '')
       check_local_files = ENV.fetch('CHECK_LOCAL_FILES', 'false').casecmp('true').zero?
       batch_size        = ENV.fetch('BATCH_SIZE', '100').to_i
+      filter_query      = ENV.fetch('S3_MIGRATION_FILTER_QUERY', '')
+      collection        = ENV.fetch('S3_MIGRATION_COLLECTION', '')
 
       puts "=== S3 Migration Status ==="
       if cutoff_date.present?
@@ -356,16 +373,24 @@ namespace :avalon do
         cutoff_time = nil
         puts "No S3_MIGRATION_CUTOFF_DATE set — counting all items."
       end
+
+      # Optional filters applied to MasterFile/Derivative Solr queries
+      extra_filter = ""
+      extra_filter += " AND #{filter_query}" if filter_query.present?
+      solr_fq = collection.present? ? media_object_join_clause(collection) : nil
+
+      puts "Filter query: #{filter_query}" if filter_query.present?
+      puts "Collection: #{collection}" if collection.present?
       puts ""
 
       # ── MasterFiles ──
-      mf_total_q = "has_model_ssim:MasterFile AND file_location_ssi:[* TO *]#{date_filter}"
-      mf_s3_q    = "has_model_ssim:MasterFile AND file_location_ssi:s3\\:\\/\\/*#{date_filter}"
-      mf_local_q = "has_model_ssim:MasterFile AND file_location_ssi:[* TO *] AND -file_location_ssi:s3\\:\\/\\/*#{date_filter}"
+      mf_total_q = "has_model_ssim:MasterFile AND file_location_ssi:[* TO *]#{date_filter}#{extra_filter}"
+      mf_s3_q    = "has_model_ssim:MasterFile AND file_location_ssi:s3\\:\\/\\/*#{date_filter}#{extra_filter}"
+      mf_local_q = "has_model_ssim:MasterFile AND file_location_ssi:[* TO *] AND -file_location_ssi:s3\\:\\/\\/*#{date_filter}#{extra_filter}"
 
-      mf_total = solr_count(mf_total_q)
-      mf_s3    = solr_count(mf_s3_q)
-      mf_local = solr_count(mf_local_q)
+      mf_total = solr_count(mf_total_q, fq: solr_fq)
+      mf_s3    = solr_count(mf_s3_q, fq: solr_fq)
+      mf_local = solr_count(mf_local_q, fq: solr_fq)
 
       puts "MasterFiles (with file_location): #{mf_total}"
       puts "  On S3:           #{mf_s3}"
@@ -376,13 +401,13 @@ namespace :avalon do
       puts ""
 
       # ── Derivatives ──
-      d_total_q = "has_model_ssim:Derivative AND derivativeFile_ssi:[* TO *]#{date_filter}"
-      d_s3_q    = "has_model_ssim:Derivative AND derivativeFile_ssi:s3\\:\\/\\/*#{date_filter}"
-      d_local_q = "has_model_ssim:Derivative AND derivativeFile_ssi:file\\:\\/\\/*#{date_filter}"
+      d_total_q = "has_model_ssim:Derivative AND derivativeFile_ssi:[* TO *]#{date_filter}#{extra_filter}"
+      d_s3_q    = "has_model_ssim:Derivative AND derivativeFile_ssi:s3\\:\\/\\/*#{date_filter}#{extra_filter}"
+      d_local_q = "has_model_ssim:Derivative AND derivativeFile_ssi:file\\:\\/\\/*#{date_filter}#{extra_filter}"
 
-      d_total = solr_count(d_total_q)
-      d_s3    = solr_count(d_s3_q)
-      d_local = solr_count(d_local_q)
+      d_total = solr_count(d_total_q, fq: solr_fq)
+      d_s3    = solr_count(d_s3_q, fq: solr_fq)
+      d_local = solr_count(d_local_q, fq: solr_fq)
 
       puts "Derivatives (with derivativeFile): #{d_total}"
       puts "  On S3:           #{d_s3}"
@@ -422,8 +447,9 @@ namespace :avalon do
 
         puts "Checking MasterFiles on filesystem..."
         loop do
-          response = ActiveFedora::SolrService.get(mf_local_q,
-            fl: 'id,file_location_ssi,isPartOf_ssim', rows: batch_size, start: start)
+          solr_params = { fl: 'id,file_location_ssi,isPartOf_ssim', rows: batch_size, start: start }
+          solr_params[:fq] = solr_fq if solr_fq
+          response = ActiveFedora::SolrService.get(mf_local_q, solr_params)
           docs = response['response']['docs']
           break if docs.empty?
 
@@ -468,8 +494,9 @@ namespace :avalon do
 
         puts "Checking Derivatives on filesystem..."
         loop do
-          response = ActiveFedora::SolrService.get(d_local_q,
-            fl: 'id,derivativeFile_ssi,isDerivationOf_ssim', rows: batch_size, start: start)
+          solr_params = { fl: 'id,derivativeFile_ssi,isDerivationOf_ssim', rows: batch_size, start: start }
+          solr_params[:fq] = solr_fq if solr_fq
+          response = ActiveFedora::SolrService.get(d_local_q, solr_params)
           docs = response['response']['docs']
           break if docs.empty?
 
@@ -564,8 +591,21 @@ namespace :avalon do
 
     # ── Helpers ─────────────────────────────────────────────────────────
 
-    def solr_count(query)
-      ActiveFedora::SolrService.get(query, rows: 0)['response']['numFound']
+    # Build a Solr join clause that filters MasterFiles by their parent
+    # MediaObject belonging to the given collection. Uses Solr's {!join}
+    # to run the subquery server-side, scaling to any collection size.
+    #
+    # Example:
+    #   media_object_join_clause('My Collection')
+    #   => '{!join from=id to=isPartOf_ssim}has_model_ssim:MediaObject AND collection_ssim:"My Collection"'
+    def media_object_join_clause(collection)
+      "{!join from=id to=isPartOf_ssim}has_model_ssim:MediaObject AND collection_ssim:\"#{collection}\""
+    end
+
+    def solr_count(query, fq: nil)
+      params = { rows: 0 }
+      params[:fq] = fq if fq
+      ActiveFedora::SolrService.get(query, params)['response']['numFound']
     end
 
     def percentage(numerator, denominator)

--- a/lib/tasks/migrate_to_s3.rake
+++ b/lib/tasks/migrate_to_s3.rake
@@ -258,10 +258,16 @@ namespace :avalon do
 
     desc "Validate ActiveStorage blobs migrated to S3 (checksum + size)"
     task validate_active_storage: :environment do
-      dry_run = ENV.fetch('DRY_RUN', 'false').casecmp('true').zero?
+      dry_run             = ENV.fetch('DRY_RUN', 'false').casecmp('true').zero?
       target_service_name = ENV.fetch('TARGET_SERVICE', 'amazon')
+      cutoff_date         = ENV.fetch('S3_MIGRATION_CUTOFF_DATE', '')
 
       s3_blobs = ActiveStorage::Blob.where(service_name: target_service_name)
+      if cutoff_date.present?
+        cutoff_time = Time.parse(cutoff_date)
+        s3_blobs = s3_blobs.where("created_at < ?", cutoff_time)
+        puts "Cutoff date: #{cutoff_date} — only validating blobs created before this date"
+      end
       total = s3_blobs.count
 
       puts "Found #{total} ActiveStorage blob(s) on #{target_service_name}"

--- a/lib/tasks/migrate_to_s3.rake
+++ b/lib/tasks/migrate_to_s3.rake
@@ -11,6 +11,10 @@
  #   6. rake avalon:migrate:s3_migration_report           # View audit trail summary
 #   7. rake avalon:migrate:validate_active_storage       # Validate ActiveStorage blobs on S3
 #
+# Rollback:
+#   rake avalon:migrate:revert_s3_migration            # Revert MasterFile+Derivative records to local paths
+#   rake avalon:migrate:revert_active_storage           # Revert ActiveStorage blobs to local service
+#
 # An audit trail is written automatically to S3 during steps 2 and 3.
 # Each entry is stored as an individual S3 object under a configurable prefix:
 #   S3_MIGRATION_LOG_BUCKET  (default: Settings.encoding.masterfile_bucket)
@@ -589,7 +593,168 @@ namespace :avalon do
       puts "==========================="
     end
 
+    # ── Revert MasterFile / Derivative records to local paths ───────────
+
+    desc "Revert MasterFile and Derivative records from S3 back to local filesystem paths"
+    task revert_s3_migration: :environment do
+      batch_size   = ENV.fetch('BATCH_SIZE', '100').to_i
+      dry_run      = ENV.fetch('DRY_RUN', 'false').casecmp('true').zero?
+      filter_query = ENV.fetch('S3_MIGRATION_FILTER_QUERY', '')
+      collection   = ENV.fetch('S3_MIGRATION_COLLECTION', '')
+      cutoff_date  = ENV.fetch('S3_MIGRATION_CUTOFF_DATE', '')
+
+      masterfile_base  = ENV.fetch('MIGRATE_MASTERFILE_LOCAL_BASE', '/masterfiles')
+      derivative_base  = ENV.fetch('MIGRATE_DERIVATIVE_LOCAL_BASE',
+                           ENV.fetch('LOCAL_DERIVATIVES_DIR', '/streamfiles'))
+
+      puts "=== Revert S3 Migration ==="
+      puts "[DRY RUN] No records will be changed" if dry_run
+      puts "MasterFile local base:  #{masterfile_base}"
+      puts "Derivative local base:  #{derivative_base}"
+
+      # ── Revert MasterFiles ──
+      mf_query = "has_model_ssim:MasterFile AND file_location_ssi:s3\\:\\/\\/*"
+      mf_query += " AND system_create_dtsi:[* TO #{cutoff_date}]" if cutoff_date.present?
+      mf_query += " AND #{filter_query}" if filter_query.present?
+      solr_fq = collection.present? ? media_object_join_clause(collection) : nil
+
+      start = 0
+      mf_reverted = 0
+      mf_errors   = 0
+      d_reverted  = 0
+      d_errors    = 0
+
+      puts ""
+      puts "Reverting MasterFiles and their Derivatives from S3 to local paths..."
+      puts "Cutoff date: #{cutoff_date}" if cutoff_date.present?
+      puts "Filter query: #{filter_query}" if filter_query.present?
+      puts "Collection: #{collection}" if collection.present?
+
+      loop do
+        solr_params = { fl: 'id,file_location_ssi', rows: batch_size, start: start }
+        solr_params[:fq] = solr_fq if solr_fq
+        response = ActiveFedora::SolrService.get(mf_query, solr_params)
+        docs = response['response']['docs']
+        break if docs.empty?
+
+        docs.each do |doc|
+          s3_uri = doc['file_location_ssi']
+          next if s3_uri.blank?
+
+          local_path = s3_uri_to_local_path(s3_uri, masterfile_base)
+
+          if dry_run
+            puts "  [DRY RUN] Would revert MasterFile #{doc['id']}: #{s3_uri} -> #{local_path}"
+            mf_reverted += 1
+            next
+          end
+
+          begin
+            master_file = MasterFile.find(doc['id'])
+            master_file.file_location = local_path
+            master_file.save!
+            mf_reverted += 1
+            puts "  Reverted MasterFile #{doc['id']}"
+
+            # Revert S3-based derivatives belonging to this MasterFile
+            master_file.derivatives.each do |derivative|
+              d_s3_uri = derivative.absolute_location
+              next if d_s3_uri.blank? || !d_s3_uri.start_with?('s3://')
+
+              d_local_path = s3_uri_to_local_path(d_s3_uri, derivative_base)
+              file_uri     = "file://#{d_local_path}"
+
+              begin
+                # absolute_location= triggers set_streaming_locations! which
+                # recalculates location_url and hls_url based on current config.
+                # Since config targets S3 (/s3-avalon/streamfiles), we must fix
+                # the URLs to use the filesystem streaming path (/avalon).
+                derivative.absolute_location = file_uri
+                derivative.hls_url = derivative.hls_url&.gsub('/s3-avalon/streamfiles', '/avalon')
+                derivative.location_url = derivative.location_url&.gsub('/s3-avalon/streamfiles', '/avalon')
+                derivative.save!
+                d_reverted += 1
+                puts "    Reverted Derivative #{derivative.id}"
+              rescue => e
+                d_errors += 1
+                puts "    ERROR Derivative #{derivative.id}: #{e.class} - #{e.message}"
+              end
+            end
+          rescue => e
+            mf_errors += 1
+            puts "  ERROR MasterFile #{doc['id']}: #{e.class} - #{e.message}"
+          end
+        end
+
+        start += batch_size
+        puts "  Processed #{start} records..." if (start % 500).zero?
+      end
+
+      puts ""
+      puts "=== Revert Complete ==="
+      puts "  MasterFiles:  #{mf_reverted} reverted, #{mf_errors} errors"
+      puts "  Derivatives:  #{d_reverted} reverted, #{d_errors} errors"
+    end
+
+    # ── Revert ActiveStorage blobs to local service ─────────────────────
+
+    desc "Revert ActiveStorage blobs from S3 back to local disk service"
+    task revert_active_storage: :environment do
+      dry_run             = ENV.fetch('DRY_RUN', 'false').casecmp('true').zero?
+      target_service_name = ENV.fetch('TARGET_SERVICE', 'amazon')
+      cutoff_date         = ENV.fetch('S3_MIGRATION_CUTOFF_DATE', '')
+
+      s3_blobs = ActiveStorage::Blob.where(service_name: target_service_name)
+      if cutoff_date.present?
+        cutoff_time = Time.parse(cutoff_date)
+        s3_blobs = s3_blobs.where("created_at < ?", cutoff_time)
+        puts "Cutoff date: #{cutoff_date} — only reverting blobs created before this date"
+      end
+      total = s3_blobs.count
+
+      puts "=== Revert ActiveStorage ==="
+      puts "Found #{total} ActiveStorage blob(s) on #{target_service_name}"
+      puts "[DRY RUN] No records will be changed" if dry_run
+
+      if total.zero?
+        puts "Nothing to revert."
+        next
+      end
+
+      reverted = 0
+      errors   = 0
+
+      s3_blobs.find_each do |blob|
+        if dry_run
+          puts "  [DRY RUN] Would revert blob #{blob.id}: #{blob.filename} (#{blob.byte_size} bytes)"
+          reverted += 1
+          next
+        end
+
+        begin
+          blob.update_column(:service_name, 'local')
+          reverted += 1
+          puts "  Reverted blob #{blob.id}: #{blob.filename}"
+        rescue => e
+          errors += 1
+          puts "  ERROR blob #{blob.id}: #{e.class} - #{e.message}"
+        end
+      end
+
+      puts ""
+      puts "ActiveStorage revert complete: #{reverted} reverted, #{errors} errors out of #{total} total"
+    end
+
     # ── Helpers ─────────────────────────────────────────────────────────
+
+    # Reverse an S3 URI to a local filesystem path.
+    # s3://bucket/archive/2v/23/vt/36/id-file.mp4 -> /masterfiles/archive/2v/23/vt/36/id-file.mp4
+    # s3://bucket/uuid/outputs/name-high.mp4      -> /streamfiles/uuid/outputs/name-high.mp4
+    def s3_uri_to_local_path(s3_uri, local_base)
+      uri = Addressable::URI.parse(s3_uri)
+      key = Addressable::URI.unencode(uri.path).sub(%r{^/}, '')
+      File.join(local_base, key)
+    end
 
     # Build a Solr join clause that filters MasterFiles by their parent
     # MediaObject belonging to the given collection. Uses Solr's {!join}

--- a/lib/tasks/migrate_to_s3.rake
+++ b/lib/tasks/migrate_to_s3.rake
@@ -7,6 +7,7 @@
 #   2. rake avalon:migrate:enqueue_s3_migration          # Enqueue MasterFile+Derivative jobs
 #   3. rake avalon:migrate:active_storage_to_s3          # Migrate SupplementalFile blobs
 #   4. rake avalon:migrate:s3_migration_status          # Monitor progress
+#   5. rake avalon:migrate:enqueue_s3_validation         # Post-migration checksum validation
 #
 # All tasks are idempotent and safe to re-run.
 #
@@ -114,6 +115,54 @@ namespace :avalon do
 
       puts ""
       puts "ActiveStorage migration complete: #{migrated} migrated, #{errors} error(s) out of #{total} total"
+    end
+
+    # ── Enqueue post-migration validation ───────────────────────────────
+
+    desc "Enqueue S3 validation jobs for all migrated MasterFiles (Solr-based)"
+    task enqueue_s3_validation: :environment do
+      batch_size  = ENV.fetch('BATCH_SIZE', '100').to_i
+      dry_run     = ENV.fetch('DRY_RUN', 'false').casecmp('true').zero?
+      cutoff_date = ENV.fetch('CUTOFF_DATE', '')
+
+      # Find MasterFiles whose file_location starts with s3://
+      # These are the ones that have been migrated.
+      query = "has_model_ssim:MasterFile AND file_location_ssi:s3\\:\\/\\/*"
+
+      # Optional: restrict to items ingested before a cutoff date.
+      # Items ingested before this date were originally on the local filesystem.
+      # Format: ISO 8601, e.g. CUTOFF_DATE=2026-02-01T00:00:00Z
+      if cutoff_date.present?
+        query += " AND date_digitized_dtsi:[* TO #{cutoff_date}]"
+        puts "Filtering to items digitized before #{cutoff_date}"
+      end
+
+      start = 0
+      total_enqueued = 0
+
+      puts "Querying Solr for migrated (S3-based) MasterFiles..."
+      puts "[DRY RUN] No jobs will be enqueued" if dry_run
+
+      loop do
+        response = ActiveFedora::SolrService.get(query, fl: 'id,file_location_ssi', rows: batch_size, start: start)
+        docs = response['response']['docs']
+        break if docs.empty?
+
+        docs.each do |doc|
+          master_file_id = doc['id']
+          if dry_run
+            puts "  [DRY RUN] Would enqueue validation: #{master_file_id}"
+          else
+            ValidateS3MigrationJob.perform_later(master_file_id)
+          end
+          total_enqueued += 1
+        end
+
+        start += batch_size
+        puts "  Processed #{start} records..." if (start % 500).zero?
+      end
+
+      puts "#{dry_run ? 'Would enqueue' : 'Enqueued'} #{total_enqueued} MasterFile(s) for S3 validation"
     end
 
     # ── Status / progress reporting ─────────────────────────────────────

--- a/lib/tasks/migrate_to_s3.rake
+++ b/lib/tasks/migrate_to_s3.rake
@@ -316,13 +316,26 @@ namespace :avalon do
 
     desc "Show S3 migration progress for MasterFiles, Derivatives, and ActiveStorage"
     task s3_migration_status: :environment do
+      cutoff_date = ENV.fetch('S3_MIGRATION_CUTOFF_DATE', '')
+
       puts "=== S3 Migration Status ==="
+      if cutoff_date.present?
+        date_filter = " AND system_create_dtsi:[* TO #{cutoff_date}]"
+        cutoff_time = Time.parse(cutoff_date)
+        puts "Cutoff date: #{cutoff_date}"
+        puts "  Items created before this date are filesystem-origin (migration candidates)."
+        puts "  Items created after this date are S3-native (excluded from counts)."
+      else
+        date_filter = ""
+        cutoff_time = nil
+        puts "No S3_MIGRATION_CUTOFF_DATE set — counting all items."
+      end
       puts ""
 
       # ── MasterFiles ──
-      mf_total_q = "has_model_ssim:MasterFile AND file_location_ssi:[* TO *]"
-      mf_s3_q    = "has_model_ssim:MasterFile AND file_location_ssi:s3\\:\\/\\/*"
-      mf_local_q = "has_model_ssim:MasterFile AND file_location_ssi:[* TO *] AND -file_location_ssi:s3\\:\\/\\/*"
+      mf_total_q = "has_model_ssim:MasterFile AND file_location_ssi:[* TO *]#{date_filter}"
+      mf_s3_q    = "has_model_ssim:MasterFile AND file_location_ssi:s3\\:\\/\\/*#{date_filter}"
+      mf_local_q = "has_model_ssim:MasterFile AND file_location_ssi:[* TO *] AND -file_location_ssi:s3\\:\\/\\/*#{date_filter}"
 
       mf_total = solr_count(mf_total_q)
       mf_s3    = solr_count(mf_s3_q)
@@ -337,9 +350,9 @@ namespace :avalon do
       puts ""
 
       # ── Derivatives ──
-      d_total_q = "has_model_ssim:Derivative AND derivativeFile_ssi:[* TO *]"
-      d_s3_q    = "has_model_ssim:Derivative AND derivativeFile_ssi:s3\\:\\/\\/*"
-      d_local_q = "has_model_ssim:Derivative AND derivativeFile_ssi:file\\:\\/\\/*"
+      d_total_q = "has_model_ssim:Derivative AND derivativeFile_ssi:[* TO *]#{date_filter}"
+      d_s3_q    = "has_model_ssim:Derivative AND derivativeFile_ssi:s3\\:\\/\\/*#{date_filter}"
+      d_local_q = "has_model_ssim:Derivative AND derivativeFile_ssi:file\\:\\/\\/*#{date_filter}"
 
       d_total = solr_count(d_total_q)
       d_s3    = solr_count(d_s3_q)
@@ -355,8 +368,11 @@ namespace :avalon do
 
       # ── ActiveStorage blobs ──
       if defined?(ActiveStorage::Blob)
-        as_total = ActiveStorage::Blob.count
-        as_local = ActiveStorage::Blob.where(service_name: "local").count
+        scope = ActiveStorage::Blob.all
+        scope = scope.where("created_at < ?", cutoff_time) if cutoff_time
+
+        as_total = scope.count
+        as_local = scope.where(service_name: "local").count
         as_s3    = as_total - as_local
 
         puts "ActiveStorage Blobs: #{as_total}"

--- a/lib/tasks/migrate_to_s3.rake
+++ b/lib/tasks/migrate_to_s3.rake
@@ -8,7 +8,7 @@
 #   3. rake avalon:migrate:active_storage_to_s3          # Migrate SupplementalFile blobs
 #   4. rake avalon:migrate:s3_migration_status          # Monitor progress
 #   5. rake avalon:migrate:enqueue_s3_validation         # Post-migration checksum validation
- #   6. rake avalon:migrate:s3_migration_report           # View audit trail summary
+#   6. rake avalon:migrate:s3_migration_report           # View audit trail summary
 #   7. rake avalon:migrate:validate_active_storage       # Validate ActiveStorage blobs on S3
 #
 # Rollback:
@@ -404,23 +404,6 @@ namespace :avalon do
       end
       puts ""
 
-      # ── Derivatives ──
-      d_total_q = "has_model_ssim:Derivative AND derivativeFile_ssi:[* TO *]#{date_filter}#{extra_filter}"
-      d_s3_q    = "has_model_ssim:Derivative AND derivativeFile_ssi:s3\\:\\/\\/*#{date_filter}#{extra_filter}"
-      d_local_q = "has_model_ssim:Derivative AND derivativeFile_ssi:file\\:\\/\\/*#{date_filter}#{extra_filter}"
-
-      d_total = solr_count(d_total_q, fq: solr_fq)
-      d_s3    = solr_count(d_s3_q, fq: solr_fq)
-      d_local = solr_count(d_local_q, fq: solr_fq)
-
-      puts "Derivatives (with derivativeFile): #{d_total}"
-      puts "  On S3:           #{d_s3}"
-      puts "  On filesystem:   #{d_local}"
-      if d_total > 0
-        puts "  Progress:        #{percentage(d_s3, d_total)}%"
-      end
-      puts ""
-
       # ── ActiveStorage blobs ──
       if defined?(ActiveStorage::Blob)
         scope = ActiveStorage::Blob.all
@@ -491,58 +474,6 @@ namespace :avalon do
         end
         puts ""
 
-        # Check Derivatives on filesystem
-        d_missing = []
-        start = 0
-        d_checked = 0
-
-        puts "Checking Derivatives on filesystem..."
-        loop do
-          solr_params = { fl: 'id,derivativeFile_ssi,isDerivationOf_ssim', rows: batch_size, start: start }
-          solr_params[:fq] = solr_fq if solr_fq
-          response = ActiveFedora::SolrService.get(d_local_q, solr_params)
-          docs = response['response']['docs']
-          break if docs.empty?
-
-          docs.each do |doc|
-            deriv_uri = doc['derivativeFile_ssi']
-            next if deriv_uri.blank?
-            d_checked += 1
-
-            begin
-              local_path = Addressable::URI.parse(deriv_uri).path
-            rescue
-              local_path = deriv_uri.sub(%r{^file://}, '')
-            end
-
-            unless File.exist?(local_path)
-              media_object_title = media_object_title_for_derivative(doc)
-              d_missing << {
-                id: doc['id'],
-                path: local_path,
-                media_object_title: media_object_title
-              }
-            end
-          end
-
-          start += batch_size
-          puts "  Checked #{start} Derivatives..." if (start % 500).zero?
-        end
-
-        puts "Derivatives checked:  #{d_checked}"
-        puts "  Missing locally:    #{d_missing.size}"
-        if d_checked > 0
-          puts "  Missing:            #{percentage(d_missing.size, d_checked)}%"
-        end
-
-        if d_missing.any?
-          puts ""
-          puts "  Missing Derivatives:"
-          d_missing.each do |entry|
-            puts "    #{entry[:id]} | #{entry[:media_object_title]} | #{entry[:path]}"
-          end
-        end
-        puts ""
 
         # Check ActiveStorage blobs on local disk
         if defined?(ActiveStorage::Blob)

--- a/lib/tasks/migrate_to_s3.rake
+++ b/lib/tasks/migrate_to_s3.rake
@@ -25,15 +25,18 @@ namespace :avalon do
 
     desc "Enqueue S3 migration jobs for all filesystem-based MasterFiles"
     task enqueue_s3_migration: :environment do
-      batch_size = ENV.fetch('BATCH_SIZE', '100').to_i
-      dry_run    = ENV.fetch('DRY_RUN', 'false').casecmp('true').zero?
+      batch_size    = ENV.fetch('BATCH_SIZE', '100').to_i
+      dry_run       = ENV.fetch('DRY_RUN', 'false').casecmp('true').zero?
+      filter_query  = ENV.fetch('SOLR_FILTER_QUERY', '')
 
       # Find MasterFiles that have a file_location and it does NOT start with s3://
       query = "has_model_ssim:MasterFile AND file_location_ssi:[* TO *] AND -file_location_ssi:s3\\:\\/\\/*"
+      query += " AND #{filter_query}" if filter_query.present?
       start = 0
       total_enqueued = 0
 
       puts "Querying Solr for filesystem-based MasterFiles..."
+      puts "Filter query: #{filter_query}" if filter_query.present?
       puts "[DRY RUN] No jobs will be enqueued" if dry_run
 
       loop do
@@ -137,8 +140,9 @@ namespace :avalon do
 
     desc "Enqueue S3 validation jobs for all migrated MasterFiles (Solr-based)"
     task enqueue_s3_validation: :environment do
-      batch_size  = ENV.fetch('BATCH_SIZE', '100').to_i
-      dry_run     = ENV.fetch('DRY_RUN', 'false').casecmp('true').zero?
+      batch_size   = ENV.fetch('BATCH_SIZE', '100').to_i
+      dry_run      = ENV.fetch('DRY_RUN', 'false').casecmp('true').zero?
+      filter_query = ENV.fetch('SOLR_FILTER_QUERY', '')
       S3_MIGRATION_CUTOFF_DATE = ENV.fetch('S3_MIGRATION_CUTOFF_DATE', '')
 
       # Find MasterFiles whose file_location starts with s3://
@@ -153,10 +157,13 @@ namespace :avalon do
         puts "Filtering to items created before #{S3_MIGRATION_CUTOFF_DATE}"
       end
 
+      query += " AND #{filter_query}" if filter_query.present?
+
       start = 0
       total_enqueued = 0
 
       puts "Querying Solr for migrated (S3-based) MasterFiles..."
+      puts "Filter query: #{filter_query}" if filter_query.present?
       puts "[DRY RUN] No jobs will be enqueued" if dry_run
 
       loop do


### PR DESCRIPTION
The `avalon:migrate:enqueue_s3_validation` rake task will enqueue a `ValidateS3MigrationJob` for all of the items ingested prior to the S3 switchover.

ValidateS3MigrationJob - Validates the MasterFile and its Derivatives to ensure the file exists in S3, and it matches the size and checksum of the corresponding local file.

https://umd-dit.atlassian.net/browse/LIBAVALON-375