### PR TITLE
LIBAVALON-546. LTI fixes for issues from 8.2 upgrade.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -57,6 +57,15 @@ class CatalogController < ApplicationController
     ## Default parameters to send to solr for all search-like requests. See also SearchBuilder#processed_parameters
     config.default_solr_params = {
       qt: 'search',
+      # UMD Customization
+      # Fix 500 response (caused by Solr 400 response) when connecting trying to access Avalon
+      # home page with a active LTI session. This most likely due to Solr query changes for the
+      # new permission inheritance feature.
+      # See https://umd-dit.atlassian.net/browse/LIBAVALON-437 for details
+      'defType' => 'edismax',
+      'q.alt' => '*:*',
+      'df' => 'all_text_timv',
+      # End UMD Customization
       rows: 10
     }
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -36,6 +36,7 @@ import UsersTable from './components/tables/UsersTable';
 import Dashboard from './components/dashboard/Dashboard';
 import './auto-complete-open.js';
 // UMD Customization
+import './autocomplete-id-value.js';
 import UMDFacetFilter from './components/UMDFacetFilter';
 // End UMD Customization
 import '@github/auto-complete-element';

--- a/app/javascript/autocomplete-id-value.js
+++ b/app/javascript/autocomplete-id-value.js
@@ -1,0 +1,25 @@
+// UMD Customization 
+/**
+ * This code ensures that when a user selects an option from the autocomplete
+ * dropdown, the hidden input field (which holds the actual value to be
+ * submitted) is updated with the correct id, while the visible input field
+ * (which shows the user-friendly display text) is updated with the
+ * corresponding display value. This is important for maintaining data integrity
+ * and ensuring that the correct values are submitted in forms that use
+ * autocomplete functionality.
+ */
+document.addEventListener('combobox-commit', function(event) {
+  const li = event.target;
+  if (!li.matches('[role="option"]')) return;
+
+  const autoComplete = li.closest('auto-complete.typeahead');
+  if (!autoComplete) return;
+
+  const hiddenField = autoComplete.querySelector('input[type="hidden"]');
+  const displayField = autoComplete.querySelector('.typeahead-input');
+  if (!hiddenField || !displayField) return;
+
+  hiddenField.value = li.getAttribute('data-autocomplete-value');
+  displayField.value = li.textContent.trim();
+});
+// End UMD Customization

--- a/app/views/modules/_access_object.html.erb
+++ b/app/views/modules/_access_object.html.erb
@@ -35,11 +35,14 @@ Unless required by applicable law or agreed to in writing, software distributed
             <%# This div is necessary for proper rendering of the typeahead dropdown 
               without screwing up styling in the rest of the form %>
             <div style='display: flex;'>
+              <%# UMD Customization %>
               <%= render partial: 'modules/autocomplete_input', locals: { field_name: "add_#{access_object}",
                                                                           model: autocomplete_model,
+                                                                          display_helper: defined?(display_helper) ? display_helper : nil,
                                                                           id: object.id,
                                                                           data: { testid: "media-object-#{access_object}" } } %>
-            </div>
+              <%# End UMD Customization %> 
+              </div>
           <% else %>
             <%= text_field_tag "add_#{access_object}", nil,
               class: "form-control",
@@ -73,9 +76,12 @@ Unless required by applicable law or agreed to in writing, software distributed
       <tbody>
         <% if inherited_roles.present? %>
           <% inherited_roles.each do |member_object| %>
+            <%# UMD Customization %>
             <%= render 'modules/access_object_member', object: object, 
                   member_object: member_object, access_object: access_object,
+                  display_helper: defined?(display_helper) ? display_helper : nil,
                   input_disabled: input_disabled, inherited: true %>
+            <%# End UMD Customization %>
          <% end %>
        <% end %>
 
@@ -84,16 +90,22 @@ Unless required by applicable law or agreed to in writing, software distributed
             <% members.each do |key, value| %>
               <% inherited = key == :inherited %>
               <% value.each do |member_object| %>
+                <%# UMD Customization %>
                 <%= render 'modules/access_object_member', object: object, 
                       member_object: member_object, access_object: access_object,
+                      display_helper: defined?(display_helper) ? display_helper : nil,
                       input_disabled: input_disabled, inherited: inherited %>
+                <%# End UMD Customization %>
               <% end %>
             <% end %>
           <% else %>
             <% members.each do |member_object| %>
+              <%# UMD Customization %>
               <%= render 'modules/access_object_member', object: object, 
                     member_object: member_object, access_object: access_object,
+                    display_helper: defined?(display_helper) ? display_helper : nil,
                     input_disabled: input_disabled, inherited: false %>
+              <%# End UMD Customization %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/modules/_autocomplete_input.html.erb
+++ b/app/views/modules/_autocomplete_input.html.erb
@@ -13,10 +13,11 @@ Unless required by applicable law or agreed to in writing, software distributed
   specific language governing permissions and limitations under the License.
 ---  END LICENSE_HEADER BLOCK  ---
 %>
+<%# UMD Customization %>
+<%# locals: (model:, id: 'undefined', field_id: nil, field_name:, for_field: field_name, value: nil, data: nil, disabled: false, placeholder: nil, display_helper: nil) %>
 
-<%# locals: (model:, id: 'undefined', field_id: nil, field_name:, for_field: field_name, value: nil, data: nil, disabled: false, placeholder: nil) %>
-
-<auto-complete class='typeahead' src='/autocomplete?t=<%= model %>&id=<%= id %>&format=html' for="<%= for_field %>-popup">
+<% if defined?(display_helper) && display_helper.present? %>
+<auto-complete class='typeahead' src='/autocomplete?t=<%= model %>&id=<%= id %>&format=html&display_helper=true' for="<%= for_field %>-popup">
   <%= text_field_tag "#{field_name}_display", nil,
       id: field_id,
       class: "form-control typeahead-input",
@@ -27,3 +28,17 @@ Unless required by applicable law or agreed to in writing, software distributed
   <ul class='autocomplete_popup' data-testid="<%= for_field %>-popup" id="<%= for_field %>-popup"></ul>
   <div class='visually-hidden autocomplete_feedback' id="<%= for_field %>-popup-feedback"></div>
 </auto-complete>
+<% else %>
+<auto-complete class='typeahead' src='/autocomplete?t=<%= "#{model}" %>&id=<%= "#{id}" %>&format=html' for=<%= "#{for_field}-popup" %>>
+  <%= text_field_tag field_name, value,
+    id: field_id,
+    class: "form-control typeahead-input",
+    data: data,
+    data: { testid: "#{for_field}-user-input" },
+    disabled: disabled,
+    placeholder: placeholder %>
+  <ul class='autocomplete_popup' data-testid=<%= "#{for_field}-popup" %> id=<%= "#{for_field}-popup" %>></ul>
+  <div class='visually-hidden autocomplete_feedback'id=<%= "#{for_field}-popup-feedback" %>></div>
+</auto-complete>
+<% end %>
+<%# End UMD Customization %>

--- a/app/views/modules/_autocomplete_input.html.erb
+++ b/app/views/modules/_autocomplete_input.html.erb
@@ -16,14 +16,14 @@ Unless required by applicable law or agreed to in writing, software distributed
 
 <%# locals: (model:, id: 'undefined', field_id: nil, field_name:, for_field: field_name, value: nil, data: nil, disabled: false, placeholder: nil) %>
 
-<auto-complete class='typeahead' src='/autocomplete?t=<%= "#{model}" %>&id=<%= "#{id}" %>&format=html' for=<%= "#{for_field}-popup" %>>
-  <%= text_field_tag field_name, value,
-    id: field_id,
-    class: "form-control typeahead-input",
-    data: data,
-    data: { testid: "#{for_field}-user-input" },
-    disabled: disabled,
-    placeholder: placeholder %>
-  <ul class='autocomplete_popup' data-testid=<%= "#{for_field}-popup" %> id=<%= "#{for_field}-popup" %>></ul>
-  <div class='visually-hidden autocomplete_feedback'id=<%= "#{for_field}-popup-feedback" %>></div>
+<auto-complete class='typeahead' src='/autocomplete?t=<%= model %>&id=<%= id %>&format=html' for="<%= for_field %>-popup">
+  <%= text_field_tag "#{field_name}_display", nil,
+      id: field_id,
+      class: "form-control typeahead-input",
+      data: data,
+      disabled: disabled,
+      placeholder: placeholder %>
+  <%= hidden_field_tag field_name, value %>
+  <ul class='autocomplete_popup' data-testid="<%= for_field %>-popup" id="<%= for_field %>-popup"></ul>
+  <div class='visually-hidden autocomplete_feedback' id="<%= for_field %>-popup-feedback"></div>
 </auto-complete>

--- a/app/views/objects/autocomplete.html.erb
+++ b/app/views/objects/autocomplete.html.erb
@@ -15,9 +15,15 @@ Unless required by applicable law or agreed to in writing, software distributed
 %>
 
 <%# UMD Customization %>
-<% @results.each do |result| %>
-  <li role="option" data-autocomplete-value="<%= result[:id] %>" data-display-value="<%= result[:display] %>">
-    <span><%= result[:display] %></span>
-  </li>
+<% if params[:display_helper].present? %>
+  <% @results.each do |result| %>
+    <li role="option" data-autocomplete-value="<%= result[:id] %>" data-display-value="<%= result[:display] %>">
+      <span><%= result[:display] %></span>
+    </li>
+  <% end %>
+<% else %>
+  <% @results.each do |result| %>
+    <li role="option"><span><%= result[:display] %></span></li>
+  <% end %>
 <% end %>
 <%# End UMD Customization %>

--- a/app/views/objects/autocomplete.html.erb
+++ b/app/views/objects/autocomplete.html.erb
@@ -14,6 +14,10 @@ Unless required by applicable law or agreed to in writing, software distributed
 ---  END LICENSE_HEADER BLOCK  ---
 %>
 
+<%# UMD Customization %>
 <% @results.each do |result| %>
-  <li role="option"><span><%= result[:display] %></span></li>
+  <li role="option" data-autocomplete-value="<%= result[:id] %>" data-display-value="<%= result[:display] %>">
+    <span><%= result[:display] %></span>
+  </li>
 <% end %>
+<%# End UMD Customization %>

--- a/lib/tasks/umd.rake
+++ b/lib/tasks/umd.rake
@@ -132,6 +132,17 @@ namespace :umd do
       end
     end
   end
+
+  desc "Provision a LTI course and user for testing purposes"
+  task provision_test_lti_course_and_user: :environment do
+    # Provision a test LTI course and user
+    context_id = ENV['TEST_LTI_COURSE_CONTEXT_ID'] || 'test-course-context-id'
+    title = ENV['TEST_LTI_COURSE_TITLE'] || 'Test Course Title'
+    email = "#{context_id}@#{ENV['SETTINGS__DOMAIN__HOST']}"
+    Course.create(context_id: context_id, label: title, title: title) unless Course.exists?(context_id: context_id)
+    User.find_or_create_by_username_or_email(title, email, 'lti')
+    Rails.logger.info("Provisioned test LTI course and user for testing purposes.")
+  end
 end
 
 def process_encode(encode)

--- a/umd_docs/AvalonTestPlan.md
+++ b/umd_docs/AvalonTestPlan.md
@@ -196,50 +196,134 @@ steps is *not* displayed (as it is not an active token). Change the
 "Filter by status" dropdown to "revoked" and left-click the "Go" button.
 Verify that the access token added in the previous steps is in the list.
 
-### 6) robots.txt
+### 6) LTI Flow
 
-**Note:** This step cannot be tested in the local development environment.
+**Note:** Steps 6.1 and 6.2 require access to a running Docker environment or
+Kubernetes namespace. The rake task provisions a test course and user.
 
-6.1) In a web browser go to
+6.1) In a terminal, run the following rake task to provision a test LTI course
+and user:
 
-<https://av-test.lib.umd.edu/robots.txt>
+```bash
+docker compose exec avalon bash -c "rails umd:provision_test_lti_course_and_user"
+```
 
-Verify the contents of a "robots.txt" file is displayed.
+The task defaults to `context_id=test-course-context-id` and
+`title=Test Course Title`. To customise, set the `TEST_LTI_COURSE_CONTEXT_ID`
+and `TEST_LTI_COURSE_TITLE` environment variables.
 
-### 7) sitemap.xml
+6.2) From the navigation bar, select "Manage | Manage Content" to go to the
+Manage Content page. Create a new unit named **Streaming Reserves** and
+within it create a new collection named **Digitized Items**:
+
+  a) Left-click the "+ Create Unit" button. On the "New unit" page, enter
+     **Streaming Reserves** in the Name field, then left-click "Create Unit".
+     The unit detail page for "Streaming Reserves" will be displayed.
+
+  b) On the "Streaming Reserves" unit page, left-click the "Create Collection"
+     button. On the "New collection" page, fill out the following fields:
+
+     | Field | Value |
+     | ----- | ----- |
+     | Name  | Digitized Items |
+     | Unit  | Streaming Reserves (pre-filled) |
+
+  then left-click the "Create Collection" button. Verify that the collection
+  is created successfully.
+
+6.3) On the "Digitized Items" collection page, left-click the
+"Create an Item" button and create a new item following the same steps as
+section 4 (upload a video file, add a title and publication date, continue
+through Structure, and reach the "Access Control" step).
+
+6.4) On the "Edit Media Object > Access Control" page, add the test course as
+an external group:
+
+  a) In the **External Groups** field, start typing `Test Course` (or the
+     title used in step 6.1). An autocomplete dropdown will appear with
+     formatted values (Eg. 1: Test Course Title).
+
+  b) Left-clicking on the test course entry in the dropdown should fill the
+     formatted value in the External Groups field, then left-click the "Add"
+     button.
+
+  c) Verify that the page reloads and the formatted course title is listed
+     under the **External Groups** section (Eg. _1:_ Test Course Title).
+
+Left-click the "Save and continue" button. The item detail page will be
+displayed.
+
+6.5) Publish the item by left-clicking the "Publish" button on the item detail
+page and verify that a success notification is displayed.
+
+6.6) From the navigation bar, select "Manage | View Courses". The "Courses"
+page will be displayed. Locate the test course created in step 6.1 and
+left-click the "Browse Course Items" button next to it. 
+
+6.7) Verify that the browse page is displayed, that the item created in step 6.3
+is listed in the results, and that the left facet panel shows **Test Course
+Title** (or the title used in step 6.1) pre-selected under the **Course Name**
+facet.
+
+6.8) From the navigation bar, select "Manage | View Courses". The "Courses"
+page will be displayed. Locate the test course created in step 6.1 and
+left-click the "Impersonate" button next to it.
+
+6.9) Verify that the course view is displayed and that the item created in step
+6.3 is listed in the course view.
+
+6.10) In the browser, navigate to
+
+<http://av-local:3000>
+
+Verify that the home page renders correctly within the LTI session. Then
+left-click the "Sign out" link and verify that the LTI session is ended
+successfully.
+
+### 7) robots.txt
 
 **Note:** This step cannot be tested in the local development environment.
 
 7.1) In a web browser go to
 
+<https://av-test.lib.umd.edu/robots.txt>
+
+Verify the contents of a "robots.txt" file is displayed.
+
+### 8) sitemap.xml
+
+**Note:** This step cannot be tested in the local development environment.
+
+8.1) In a web browser go to
+
 <https://av-test.lib.umd.edu/sitemap.xml>
 
 Verify that a "sitemap" file is returned.
 
-### 8) Item Deletion
+### 9) Item Deletion
 
-8.1) Go back to the item detail page of the item added in the previous steps.
+9.1) Go back to the item detail page of the item added in the previous steps.
 
-8.2) On the item detail page, left-click the "Edit" button. The
+9.2) On the item detail page, left-click the "Edit" button. The
 "Edit Media Object > Access Control" page will be displayed.
 
-8.3) On the "Edit Media Object > Access Control" page, left-click the
+9.3) On the "Edit Media Object > Access Control" page, left-click the
 "Delete this item" button at the bottom of the left sidebar. A confirmation
 page will be displayed.
 
-8.4) On the confirmation page, left-click the "Yes, I am sure" button. The
+9.4) On the confirmation page, left-click the "Yes, I am sure" button. The
 Avalon home page will be displayed with a notification indicating that the
 media object was deleted.
 
-### 9) Collection Deletion
+### 10) Collection Deletion
 
-9.1) From the navigation bar, select "Manage | Manage Content" from the
+10.1) From the navigation bar, select "Manage | Manage Content" from the
 navigation bar. The "My Collections" page will be displayed.
 
-9.2) On the "My Collections" page, find the "SSDR Test Collection" entry in the
+10.2) On the "My Collections" page, find the "SSDR Test Collection" entry in the
 list and left-click the "Delete" button. A confirmation
 page will be displayed.
 
-9.3) On the confirmation page, left-click the "Yes, I am sure" button. The
+10.3) On the confirmation page, left-click the "Yes, I am sure" button. The
 "My Collections"" page will be displayed. Verify that the "SSDR Test Collection"
 no longer appears in the list of collections.


### PR DESCRIPTION
### Fix 500 Error in LTI Sessions

Resolved an issue where users visiting Avalon with an active LTI session from Canvas would encounter a 500 error. Prior to the upgrade, Avalon would recognize the existing LTI session and log the user in automatically, allowing them to log out and continue using the site as a regular user if desired. This fix restores the previous behavior.

### Fix Course Reserves Display Formatting

Restored the custom formatting of Course Reserves entries so that assigned courses are displayed as a combination of the local ID and course title. This customization was broken by an upstream refactoring that introduced a new submodule for `access_object.html.erb` without passing a parameter required by the customization. The missing parameter is now passed correctly.

### Fix Autocomplete Customization

Restored the autocomplete customization that displays a custom-formatted value (ID + title). This functionality was broken when the upstream project migrated to a new JavaScript library. The customization has been reimplemented to preserve the expected display.

### Add Local LTI Testing Support

Added a new Rake task to enable local testing of the LTI workflow, along with corresponding test instructions in the UMD Avalon Test Plan.

https://umd-dit.atlassian.net/browse/LIBAVALON-546