### PR TITLE
LIBAVALON-547. Fix 'container' null error on Playlist and Timelines pages

### DIFF
--- a/app/assets/javascripts/button_confirmation.js
+++ b/app/assets/javascripts/button_confirmation.js
@@ -29,7 +29,13 @@ window.apply_button_confirmation = function () {
       trigger: 'manual',
       html: true,
       sanitize: false,
-      container: '#main-content',
+      // UMD Customization
+      // Due to LIBAVALON-108, the #main-content element is not present on all
+      // pages (e.g. Timelines, Playlist). We fall back to 'main' as the
+      // container selector, which targets the semantic <main> element that is
+      // consistently available across the application.
+      container: 'main',
+      // End UMD Customization
       content: function () {
         let button;
         if (typeof this.getAttribute('form') === "undefined" || this.getAttribute('form') === null) {

--- a/app/assets/javascripts/media_object_accessibility.js
+++ b/app/assets/javascripts/media_object_accessibility.js
@@ -95,7 +95,13 @@ function initPublishPopover() {
           trigger: 'manual',
           html: true,
           sanitize: false,
-          container: '#main-content',
+          // UMD Customization
+          // Due to LIBAVALON-108, the #main-content element is not present on all
+          // pages (e.g. Timelines, Playlist). We fall back to 'main' as the
+          // container selector, which targets the semantic <main> element that is
+          // consistently available across the application.
+          container: 'main',
+          // End UMD Customization
           content: `<p>${this.dataset.confirmationMessage || ''}</p>` +
             '<button class="btn btn-sm btn-warning me-2" id="exempt-and-publish-btn">Exempt &amp; Publish</button>' +
             '<button class="btn btn-sm btn-primary" id="cancel-publish-btn">Cancel</button>'


### PR DESCRIPTION
Update the container selector for Bootstrap Popover to use `main` instead of `#main-content`, resolving a null error on specific pages. This change ensures consistent functionality across the application.

https://umd-dit.atlassian.net/browse/LIBAVALON-547